### PR TITLE
azcosmos: Stage 0 — query engine plumbing (BYT-9239)

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+* Added `queryengine.Disabled` sentinel and `queryengine.ErrUnsupportedPlanFeature` error, plus a new `queryengine/internal/gonative` sub-package housing the pure-Go query engine that later stages will flesh out. No behavior change in this release — the engine is inert and is not yet auto-enabled. See [BYT-9239](https://linear.app/bytebase/issue/BYT-9239).
+* Added `ClientOptions.QueryPlanCacheSize` and a per-container LRU plan cache; allocated at container construction but unused in this release.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -33,6 +33,8 @@ type Client struct {
 	internal    *azcore.Client
 	gem         *globalEndpointManager
 	endpointUrl *url.URL
+
+	queryPlanCacheSize int
 }
 
 // Endpoint used to create the client.
@@ -64,7 +66,11 @@ func NewClientWithKey(endpoint string, cred KeyCredential, o *ClientOptions) (*C
 	if err != nil {
 		return nil, err
 	}
-	return &Client{endpoint: endpoint, endpointUrl: endpointUrl, internal: internalClient, gem: gem}, nil
+	client := &Client{endpoint: endpoint, endpointUrl: endpointUrl, internal: internalClient, gem: gem}
+	if o != nil {
+		client.queryPlanCacheSize = o.QueryPlanCacheSize
+	}
+	return client, nil
 }
 
 // NewClient creates a new instance of Cosmos client with Azure AD access token authentication. It uses the default pipeline configuration.
@@ -110,7 +116,11 @@ func NewClient(endpoint string, cred azcore.TokenCredential, o *ClientOptions) (
 	if err != nil {
 		return nil, err
 	}
-	return &Client{endpoint: endpoint, endpointUrl: endpointUrl, internal: internalClient, gem: gem}, nil
+	client := &Client{endpoint: endpoint, endpointUrl: endpointUrl, internal: internalClient, gem: gem}
+	if o != nil {
+		client.queryPlanCacheSize = o.QueryPlanCacheSize
+	}
+	return client, nil
 }
 
 // NewClientFromConnectionString creates a new instance of Cosmos client from connection string. It uses the default pipeline configuration.

--- a/sdk/data/azcosmos/cosmos_client_options.go
+++ b/sdk/data/azcosmos/cosmos_client_options.go
@@ -15,4 +15,9 @@ type ClientOptions struct {
 	EnableContentResponseOnWrite bool
 	// PreferredRegions is a list of regions to be used when initializing the client in case the default region fails.
 	PreferredRegions []string
+
+	// QueryPlanCacheSize bounds the per-client LRU cache of Cosmos query plans.
+	// Zero (the default) uses the SDK default (256 entries).
+	// Negative values disable the cache entirely.
+	QueryPlanCacheSize int
 }

--- a/sdk/data/azcosmos/cosmos_client_options_test.go
+++ b/sdk/data/azcosmos/cosmos_client_options_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos_test
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryPlanCacheSizeDefaultsToSensibleValue(t *testing.T) {
+	var o azcosmos.ClientOptions
+	// Zero value is the Go default; the SDK treats zero as "use the built-in default".
+	// The field itself stores zero — callers observe the default only when the SDK allocates caches.
+	assert.Equal(t, 0, o.QueryPlanCacheSize,
+		"zero value should map to the SDK default; the field itself stores zero")
+}
+
+func TestQueryPlanCacheSizeIsSettable(t *testing.T) {
+	o := azcosmos.ClientOptions{QueryPlanCacheSize: 512}
+	assert.Equal(t, 512, o.QueryPlanCacheSize)
+}
+
+func TestQueryPlanCacheSizeNegativeIsAllowed(t *testing.T) {
+	// Interpretation of negative values is documented as "disabled".
+	o := azcosmos.ClientOptions{QueryPlanCacheSize: -1}
+	assert.Equal(t, -1, o.QueryPlanCacheSize)
+}

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 // ContainerClient lets you perform read, update, change throughput, and delete container operations.
@@ -22,7 +23,40 @@ type ContainerClient struct {
 	// The database that contains the container
 	database *DatabaseClient
 	// The resource link
-	link string
+	link      string
+	planCache *lru.Cache[planCacheKey, []byte]
+}
+
+// defaultQueryPlanCacheSize is the cache size used when
+// ClientOptions.QueryPlanCacheSize is zero.
+const defaultQueryPlanCacheSize = 256
+
+// planCacheKey uniquely identifies a cached query plan within a container.
+// The `features` component is part of the key because the same query text
+// produces different plans depending on the features the engine advertises.
+type planCacheKey struct {
+	databaseID      string
+	containerID     string
+	normalizedQuery string
+	features        string
+}
+
+// newPlanCache returns an initialized LRU cache for query plans, or nil if
+// the caller asked for caching to be disabled (negative size).
+func newPlanCache(size int) *lru.Cache[planCacheKey, []byte] {
+	switch {
+	case size < 0:
+		return nil
+	case size == 0:
+		size = defaultQueryPlanCacheSize
+	}
+	// lru.New returns an error only when size <= 0, which we have ruled out.
+	c, err := lru.New[planCacheKey, []byte](size)
+	if err != nil {
+		// Should be unreachable.
+		panic(err)
+	}
+	return c
 }
 
 // ItemIdentity represents the identity of an item (its id plus its partition key value).
@@ -42,9 +76,11 @@ type ItemIdentity struct {
 
 func newContainer(id string, database *DatabaseClient) (*ContainerClient, error) {
 	return &ContainerClient{
-		id:       id,
-		database: database,
-		link:     createLink(database.link, pathSegmentCollection, id)}, nil
+		id:        id,
+		database:  database,
+		link:      createLink(database.link, pathSegmentCollection, id),
+		planCache: newPlanCache(database.client.queryPlanCacheSize),
+	}, nil
 }
 
 // ID returns the identifier of the Cosmos container.

--- a/sdk/data/azcosmos/cosmos_container_plan_cache_test.go
+++ b/sdk/data/azcosmos/cosmos_container_plan_cache_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+// Tests in this file are in-package (not _test package) because planCache is
+// intentionally unexported — only other files in this package need to see it.
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPlanCacheDefaultSize(t *testing.T) {
+	// Passing 0 must resolve to the 256-entry default. We verify by inserting
+	// 257 distinct keys and checking the LRU evicted down to 256 — that way
+	// the test fails if newPlanCache forgets to apply the default, rather than
+	// just asserting a constant against its own literal.
+	c := newPlanCache(0)
+	require.NotNil(t, c)
+	for i := 0; i < defaultQueryPlanCacheSize+1; i++ {
+		key := planCacheKey{normalizedQuery: strconv.Itoa(i)}
+		c.Add(key, []byte("{}"))
+	}
+	assert.Equal(t, defaultQueryPlanCacheSize, c.Len(),
+		"newPlanCache(0) must produce a cache bounded at defaultQueryPlanCacheSize")
+}
+
+func TestNewPlanCacheExplicitSize(t *testing.T) {
+	c := newPlanCache(64)
+	require.NotNil(t, c)
+	assert.Equal(t, 0, c.Len())
+}
+
+func TestNewPlanCacheDisabled(t *testing.T) {
+	c := newPlanCache(-1)
+	assert.Nil(t, c, "negative size should disable the cache entirely")
+}
+
+func TestPlanCacheRoundTrip(t *testing.T) {
+	c := newPlanCache(4)
+	require.NotNil(t, c)
+	key := planCacheKey{
+		databaseID:      "db",
+		containerID:     "coll",
+		normalizedQuery: "SELECT 1",
+		features:        "",
+	}
+	payload := []byte(`{"partitionedQueryExecutionInfoVersion":2}`)
+	c.Add(key, payload)
+	got, ok := c.Get(key)
+	require.True(t, ok)
+	assert.Equal(t, payload, got)
+}

--- a/sdk/data/azcosmos/go.mod
+++ b/sdk/data/azcosmos/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/sdk/data/azcosmos/go.sum
+++ b/sdk/data/azcosmos/go.sum
@@ -16,6 +16,8 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/sdk/data/azcosmos/queryengine/cosmos_query_engine.go
+++ b/sdk/data/azcosmos/queryengine/cosmos_query_engine.go
@@ -3,6 +3,8 @@
 
 package queryengine
 
+import "errors"
+
 // QueryEngine is an interface that defines the methods for a query engine.
 type QueryEngine interface {
 	CreateQueryPipeline(query string, plan string, pkranges string) (QueryPipeline, error)
@@ -99,4 +101,29 @@ type QueryPipeline interface {
 	ProvideData(data []QueryResult) error
 	// Close frees the resources associated with the pipeline.
 	Close()
+}
+
+// ErrUnsupportedPlanFeature is returned by a QueryEngine implementation when
+// the query plan references a feature the engine has not implemented.
+// Callers receiving this should treat it as "this engine cannot serve this query"
+// and surface the original gateway error if any.
+var ErrUnsupportedPlanFeature = errors.New("azcosmos/queryengine: unsupported plan feature")
+
+// Disabled is a QueryEngine sentinel callers can use to explicitly opt out of
+// any default engine the SDK might install. Every method on Disabled returns
+// ErrUnsupportedPlanFeature.
+var Disabled QueryEngine = disabledEngine{}
+
+type disabledEngine struct{}
+
+func (disabledEngine) SupportedFeatures() string {
+	return ""
+}
+
+func (disabledEngine) CreateQueryPipeline(_ string, _ string, _ string) (QueryPipeline, error) {
+	return nil, ErrUnsupportedPlanFeature
+}
+
+func (disabledEngine) CreateReadManyPipeline(_ []ItemIdentity, _ string, _ string, _ uint8, _ []string) (QueryPipeline, error) {
+	return nil, ErrUnsupportedPlanFeature
 }

--- a/sdk/data/azcosmos/queryengine/cosmos_query_engine_test.go
+++ b/sdk/data/azcosmos/queryengine/cosmos_query_engine_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package queryengine_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisabledIsNonNilSentinel(t *testing.T) {
+	// The Disabled sentinel must be non-nil so callers can distinguish
+	// "no engine specified" (nil) from "explicitly disabled".
+	require.NotNil(t, queryengine.Disabled)
+}
+
+func TestDisabledAdvertisesNoFeatures(t *testing.T) {
+	assert.Equal(t, "", queryengine.Disabled.SupportedFeatures())
+}
+
+func TestDisabledCreateQueryPipelineReturnsUnsupported(t *testing.T) {
+	_, err := queryengine.Disabled.CreateQueryPipeline("SELECT 1", "{}", "{}")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, queryengine.ErrUnsupportedPlanFeature),
+		"Disabled.CreateQueryPipeline should return ErrUnsupportedPlanFeature; got %v", err)
+}
+
+func TestDisabledCreateReadManyPipelineReturnsUnsupported(t *testing.T) {
+	_, err := queryengine.Disabled.CreateReadManyPipeline(nil, "{}", "", 0, nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, queryengine.ErrUnsupportedPlanFeature))
+}

--- a/sdk/data/azcosmos/queryengine/docs/README.md
+++ b/sdk/data/azcosmos/queryengine/docs/README.md
@@ -1,0 +1,39 @@
+# queryengine design docs
+
+Design and implementation artifacts for the pure-Go distributed query engine
+Bytebase is adding to `sdk/data/azcosmos/queryengine`. Tracked upstream of this
+work in [Linear issue BYT-9239](https://linear.app/bytebase/issue/BYT-9239).
+
+| File | What it is |
+|---|---|
+| [`design.md`](./design.md) | The authoritative design spec — architecture, activation strategy, operator decomposition, rollout plan across seven stages, open concerns from adversarial review. |
+| [`stage-0-plan.md`](./stage-0-plan.md) | The TDD-grade implementation plan for Stage 0 (this PR's scope — plumbing only, zero behavior change). |
+| [`target-queries.md`](./target-queries.md) | The 40-query inventory that defines "parity with the Microsoft .NET SDK" concretely. Every stage's tests validate against this list. |
+
+## Reproduction harnesses
+
+The design docs reference two reproduction harnesses:
+
+- `scripts/cosmos-repro-dotnet/` — runs the 40-query inventory against the
+  Microsoft .NET SDK (`Microsoft.Azure.Cosmos 3.47.1`). Used to produce the
+  reference pass/fail column in `target-queries.md`.
+- `scripts/cosmos-repro-go/` — (Stage 7) Go twin of the above. Validates
+  that the Bytebase SDK reaches .NET parity.
+
+**Both harnesses live in the Bytebase monorepo**, not in this repository.
+They are test infrastructure, not part of the SDK itself. The SDK's own
+tests live in `sdk/data/azcosmos/**_test.go` as usual.
+
+## Stage landing order
+
+This PR (#2) is Stage 0 of 7. Each subsequent stage will add its own
+implementation plan to this directory:
+
+- Stage 0 — plumbing (this PR)
+- Stage 1 — activation + scalar aggregates
+- Stage 2 — DISTINCT
+- Stage 3 — single-key ORDER BY
+- Stage 4 — TOP
+- Stage 5 — OFFSET / LIMIT
+- Stage 6 — GROUP BY
+- Stage 7 — Go reproduction harness + end-to-end parity validation

--- a/sdk/data/azcosmos/queryengine/docs/design.md
+++ b/sdk/data/azcosmos/queryengine/docs/design.md
@@ -1,0 +1,335 @@
+# Cosmos DB Cross-Partition Query Engine (Go) — Design
+
+- **Linear issue:** BYT-9239
+- **Date:** 2026-04-22
+- **Status:** Proposed
+- **Authoritative target query list:** [`./target-queries.md`](./target-queries.md) (40 queries across 13 feature areas, each annotated with `.NET SDK` pass/fail and failure reason)
+
+## 1. Context and problem statement
+
+Bytebase's Cosmos DB SQL viewer fails on every query that requires client-side cross-partition orchestration — `TOP`, single-column `ORDER BY`, scalar aggregates in both aliased (`AS x`) and `VALUE` forms, multi-aggregate in one SELECT, `GROUP BY`, `DISTINCT`, `DISTINCT VALUE`, `SELECT VALUE agg(...)`, and `OFFSET/LIMIT`. The gateway returns `BadRequest 400`: *"The provided cross partition query can not be directly served by the gateway. … This exception is traced, but unless you see it bubble up as an exception (which only happens on older SDK clients), you can safely ignore this message."*
+
+### 1.1 Root cause
+
+Bytebase's driver imports `github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos`, replaced in `go.mod` with the fork `github.com/bytebase/azure-sdk-for-go/sdk/data/azcosmos v0.0.0-20260414094732-5b89f0889452` (commit `5b89f0889452`, 2026-04-14, on the upstream `1.5.0-beta.6 (Unreleased)` track). The fork already exposes a `queryengine.QueryEngine` interface on `QueryOptions.QueryEngine`, but neither the SDK nor Bytebase ship an implementation — Microsoft's reference implementation lives in a separate `azcosmoscx` package (Rust-backed) and is not imported.
+
+Queries that succeed in the .NET SDK (`Microsoft.Azure.Cosmos` 3.47.1, the reference implementation) fail in the Go fork for a simple reason: **the .NET SDK has a built-in distributed query engine; the Go SDK has only an interface hook.** A .NET reproduction harness (maintained in the Bytebase monorepo under `scripts/cosmos-repro-dotnet/`) confirms this — 39/40 queries PASS on .NET (Gateway and Direct modes), the one remaining FAIL is 4.3 which requires a server-side composite index and fails identically on every SDK.
+
+> The reproduction harness and the Go twin harness referenced throughout this document (`scripts/cosmos-repro-dotnet/`, `scripts/cosmos-repro-go/`) live in the Bytebase monorepo, not this repository. They are test infrastructure, not part of the SDK itself. The SDK's own tests live in `sdk/data/azcosmos/**_test.go` as usual.
+
+### 1.2 Why the obvious fixes don't work
+
+- **Sync the fork with upstream.** Already done — problem persists because upstream itself only ships the interface, not an implementation.
+- **Use `azcosmoscx`.** Rust / cgo / plugin dependency that Bytebase's codebase does not have today. Rejected.
+- **Reject cross-partition queries with better errors.** Does not make any currently-failing query pass. Rejected as insufficient.
+- **Run a .NET side-process.** Adds a runtime dependency and deployment footprint. Rejected as heavyweight.
+
+## 2. Goals and non-goals
+
+### 2.1 Goal
+Ship a **pure-Go distributed query engine** inside the Bytebase fork of `azcosmos` so that every Cosmos SQL query that succeeds on `Microsoft.Azure.Cosmos` 3.47.1 also succeeds against the same account through Bytebase, with matching row output.
+
+The authoritative target list is the 40-query inventory in the plan file referenced at the top of this document. For each query, the `.NET SDK` column defines the expected pass/fail outcome; the Go engine must match it. 39/40 must pass; query 4.3 remains FAIL because it requires a composite index — a server constraint, not an SDK gap.
+
+### 2.2 Non-goals
+1. Not implementing any feature the .NET SDK itself doesn't support against a serverless account.
+2. Not vendoring, cgo-linking, or plugin-loading Microsoft's `azcosmoscx` (Rust) engine.
+3. Not upstreaming the implementation to `Azure/azure-sdk-for-go` in the same delivery. (Follow-up.)
+4. Not changing any Bytebase driver, parser, or UI surface for this fix. (A one-line `go.mod` bump is the only Bytebase-side change.)
+5. Not optimizing for high-QPS analytical workloads — correctness first; perf work is a follow-up if latency/memory becomes a problem in practice.
+
+### 2.3 Success criteria
+- `scripts/cosmos-repro-dotnet/` has a Go twin that runs the same target query list. 39 of 40 pass; 4.3 continues to fail with the same server error as .NET.
+- The new engine is auto-enabled in `container.NewCrossPartitionQueryItemsPager`; callers get correct results without code changes.
+- CI unit tests pass in under 30 s, mocked end-to-end. Integration suite runs when `AZURE_COSMOS_KEY` is set; skipped otherwise.
+
+## 3. SDK architecture
+
+### 3.1 Package layout in the fork
+
+```
+sdk/data/azcosmos/
+├── queryengine/                       # existing — interface & types
+│   ├── cosmos_query_engine.go         # existing
+│   └── internal/
+│       └── gonative/                  # NEW — pure-Go default implementation
+│           ├── engine.go              # implements queryengine.QueryEngine
+│           ├── pipeline.go            # QueryPipeline fsm
+│           ├── plan.go                # JSON model of the query plan
+│           ├── merge.go               # k-way ORDER BY merge
+│           ├── agg.go                 # COUNT/SUM/MIN/MAX/AVG finalizers
+│           ├── distinct.go            # hash-set dedupe
+│           ├── group.go               # GROUP BY hashmap
+│           ├── topskiptake.go         # TOP / OFFSET / LIMIT
+│           └── *_test.go              # unit tests (mocked plans + partition data)
+├── cosmos_container_query_engine.go   # existing — modify to default-wire gonative
+└── cosmos_container.go                # existing — NewCrossPartitionQueryItemsPager unchanged externally
+```
+
+`gonative` lives under `internal/` so its package surface is not part of the SDK's public API. Only the `queryengine.QueryEngine` interface implementation escapes — everything else in `gonative` can be refactored freely by later stages. No new public API on the `azcosmos` package itself.
+
+### 3.2 Activation
+
+Auto-enable with a safe fallback:
+
+1. If `QueryOptions.QueryEngine == nil`, the SDK injects `gonative.Default()` at the top of `NewCrossPartitionQueryItemsPager`. Callers retain full control: passing a non-nil value overrides; passing a new sentinel `queryengine.Disabled` preserves today's raw-pass-through behavior as an escape hatch.
+2. For every cross-partition query, the SDK fetches the plan. The plan response tells us whether the gateway can serve it directly. If yes, we skip the engine and run the existing fast path — **zero orchestration overhead for single-partition queries beyond the plan round-trip**.
+3. An in-memory LRU plan cache keyed by `(databaseID, containerID, normalizedQuery, features)` on `ContainerClient` (default 256 entries, configurable via `CosmosClientOptions.QueryPlanCacheSize`) amortizes the plan-fetch cost across a SQL-viewer session.
+
+### 3.3 Data flow
+
+```
+Bytebase.QueryConn
+  └─ azcosmos.NewCrossPartitionQueryItemsPager
+       ├─ (cache-miss) getQueryPlanFromGateway → plan JSON
+       ├─ getPartitionKeyRangesRaw              → pkranges JSON
+       ├─ engine.CreateQueryPipeline(query, plan, pkranges) → QueryPipeline
+       └─ Pager loop (drives pipeline):
+            for req in pipeline.NextRequests():
+                resp = sendQuery(req.PKRangeID, req.Query, req.Continuation)
+                pipeline.Feed(QueryResult{...})
+            rows = pipeline.Drain()
+       → returns a page of merged rows
+```
+
+For a gateway-servable query, the pipeline's `NextRequests()` returns a single pass-through request with no rewrite and `Drain()` is just a stream of raw rows — no added work.
+
+### 3.4 Memory and streaming
+
+| Operator | Intermediate state | Can emit incrementally? |
+|---|---|---|
+| Pass-through | O(page) | Yes |
+| `ORDER BY` (single key) | O(partitions × 1 row) — k-way merge heap | Yes |
+| `TOP N` / `OFFSET+LIMIT` | O(N) | Yes (emits as soon as window fills) |
+| `DISTINCT` | O(distinct cardinality) — hash set of seen keys | Yes (emit first occurrence) |
+| `GROUP BY` | O(group cardinality) — hashmap of state | No — must drain all partitions first |
+| Scalar aggregates (`COUNT`, `SUM`, `MIN`, `MAX`, `AVG`) | O(1) per aggregate | No — emits single final row |
+
+`GROUP BY` and scalar aggregates require draining all partitions before any row is emitted. Everything else streams. The Bytebase driver's existing `queryContext.Limit` early-termination loop at `cosmosdb.go:172-190` continues to work for streaming operators; for non-streaming operators, `Limit` caps the emitted row count at the end (same semantics as any DB).
+
+### 3.5 Error handling
+
+The engine never invents error types. Gateway errors propagate through unchanged (so the UI keeps seeing the same `BadRequest` for query 4.3's composite-index case). A plan feature the engine hasn't implemented returns `queryengine.ErrUnsupportedPlanFeature`; the pager falls back to the raw pass-through — i.e. current behavior — so partially-landed stages never make things worse.
+
+## 4. Rollout order and per-stage scope
+
+Seven PRs in dependency order. Each is reviewable standalone, behind a feature announcement in `SupportedFeatures()`, and adds no regression to queries outside its scope.
+
+### Stage 0 — Engine skeleton
+`queryengine/internal/gonative/` package skeleton; default-wiring in `NewCrossPartitionQueryItemsPager`; plan fetch + pk-ranges + LRU plan cache; a pass-through pipeline; `SupportedFeatures()` returns empty — gateway refuses any cross-partition orchestration, exactly like today. **Queries covered:** none (parity). **Tests:** unit (plan cache, pass-through, fallback); integration asserts no regression on the 20 queries currently passing in Go (1.1, 1.2, 2.1–2.9, 3.1–3.3, 7.1, 8.1, 9.1, 9.2, 11.1, 13.1) and the 20 still failing (1.3, 4.1–4.3, 5.1/5.1b/5.2/5.2b/5.3/5.3b/5.4/5.4b/5.5, 6.1, 6.2, 10.1, 10.2, 11.2, 12.1, 12.2).
+
+### Stage 1 — Scalar aggregates
+`agg.go` with finalizers for `COUNT`, `SUM`, `MIN`, `MAX`, `AVG`. Both `SELECT VALUE agg(x) FROM c` and `SELECT agg(x) AS alias FROM c` (gateway rewrites aliased form to `VALUE` then the pipeline wraps scalar into `{alias: value}`). Multi-aggregate in one SELECT via a parallel state vector. **Queries covered:** 5.1, 5.1b, 5.2, 5.2b, 5.3, 5.3b, 5.4, 5.4b, 5.5, 11.2.
+
+### Stage 2 — DISTINCT
+`distinct.go`: streaming hash-set keyed on canonical JSON (sorted keys) of the distinct projection. Both object DISTINCT and `DISTINCT VALUE`. Ordered DISTINCT composes with Stage 3 automatically. **Queries covered:** 10.1, 10.2.
+
+### Stage 3 — ORDER BY (single key)
+`merge.go`: min-heap (or max-heap) k-way merge across partition streams, typed comparator using Cosmos item ordering (`undefined < null < bool < number < string`). ASC and DESC. Multi-key ORDER BY (4.3) is **not** added — server-side composite-index requirement, out of scope. **Queries covered:** 4.1, 4.2.
+
+### Stage 4 — TOP
+`topskiptake.go`: wraps upstream operator, emits first N, cancels upstream on satisfaction (streaming early-termination). Stacks on Stage 3's merger. **Queries covered:** 1.3.
+
+### Stage 5 — OFFSET / LIMIT
+Extends Stage 4 with a skip counter. Cosmos syntactically requires `ORDER BY` before `OFFSET/LIMIT`, so upstream is always the merger. **Queries covered:** 12.1, 12.2.
+
+### Stage 6 — GROUP BY
+`group.go`: `map[groupKey]*aggState` where `aggState` reuses Stage 1's finalizers. Drains all partitions, emits one row per group. **Queries covered:** 6.1, 6.2.
+
+### Stage 7 — Repro-harness parity (Go twin)
+`scripts/cosmos-repro-go/` mirroring `scripts/cosmos-repro-dotnet/`. Running both against the same target list should produce the same PASS/FAIL column for all 40 queries. Becomes the regression guard for BYT-9239.
+
+### Cumulative pass count from the 40-query inventory
+
+| Stage | `SupportedFeatures()` added | Queries unlocked | Cumulative PASS |
+|---|---|---|---|
+| 0 | *(none)* | 0 | 20 / 40 |
+| 1 | `Aggregate` | 10 (5.1, 5.1b, 5.2, 5.2b, 5.3, 5.3b, 5.4, 5.4b, 5.5, 11.2) | 30 / 40 |
+| 2 | `Distinct` | 2 (10.1, 10.2) | 32 / 40 |
+| 3 | `OrderBy` | 2 (4.1, 4.2) | 34 / 40 |
+| 4 | `Top` | 1 (1.3) | 35 / 40 |
+| 5 | `OffsetAndLimit` | 2 (12.1, 12.2) | 37 / 40 |
+| 6 | `GroupBy` | 2 (6.1, 6.2) | 39 / 40 |
+| 7 | *(harness)* | 0 | 39 / 40 (confirmed end-to-end against Azure) |
+
+The permanent FAIL is 4.3 (composite-index server constraint — out of scope for any SDK).
+
+## 5. Per-stage engineering details
+
+### 5.1 Wire shapes (Stage 0)
+
+Query plan JSON (trimmed to relevant fields):
+
+```json
+{
+  "partitionedQueryExecutionInfoVersion": 2,
+  "queryInfo": {
+    "rewrittenQuery": "SELECT ... FROM c WHERE ...",
+    "hasSelectValue": true,
+    "hasNonStreamingOrderBy": false,
+    "distinctType": "None | Ordered | Unordered",
+    "top": null,
+    "offset": null,
+    "limit": null,
+    "orderBy": ["Ascending"],
+    "orderByExpressions": ["c.population"],
+    "groupByExpressions": [],
+    "groupByAliases": [],
+    "aggregates": ["Count"],
+    "groupByAliasToAggregateType": {}
+  },
+  "queryRanges": [{"min": "...", "max": "...", "isMinInclusive": true, "isMaxInclusive": false}]
+}
+```
+
+`rewrittenQuery` is the per-partition sub-query. Empty means "use the original query unchanged." The pk-ranges response is a list of `{id, minInclusive, maxExclusive}` entries; we fire one partition request per entry that overlaps the plan's `queryRanges`.
+
+**Plan cache.** New private field on `ContainerClient`:
+
+```go
+planCache *lru.Cache[planCacheKey, []byte]   // default 256 entries
+type planCacheKey struct{ dbID, containerID, normalizedQuery, features string }
+```
+
+Stored value is the raw plan bytes; re-parse on every use (parse cost is negligible next to the RTT).
+
+### 5.2 Pipeline FSM (Stage 0, reused by every later stage)
+
+```go
+type pipeline struct {
+    plan          *planDoc
+    partitions    []partitionState      // one per overlapping pk-range
+    operator      operator              // built from plan
+    pendingReqs   []queryengine.QueryRequest
+    doneOnce      sync.Once
+    err           error
+}
+
+type operator interface {
+    Next(ctx context.Context) (row json.RawMessage, ok bool, err error)
+}
+```
+
+Operators compose top-down: passthrough → orderByMerge → topSkipTake → aggregate → groupBy → distinct. `NextRequests()` returns the initial batch (one request per partition) and later batches for partitions with continuation tokens still outstanding. `Feed()` parses a `QueryResult`'s `Data` into `[]json.RawMessage` and pushes to that partition's buffered channel. `NextRows()` pulls from `operator.Next()` and emits whatever's ready.
+
+### 5.3 Concurrency
+
+One goroutine per active partition, each pulling one page's continuation at a time. Bounded semaphore caps in-flight requests at `min(len(partitions), runtime.GOMAXPROCS(0))`. Context cancellation unblocks everything. `errgroup` coordinates failures.
+
+### 5.4 Operator details
+
+**Stage 1 — Aggregates.** Gateway emits partials in documented wire forms:
+
+- `Count`: raw integer per partition.
+- `Sum`: raw number per partition.
+- `Min` / `Max`: `{"min": v, "count": n}` or `{"max": v, "count": n}`; n=0 means "this partition had no values" and is skipped.
+- `Avg`: `{"sum": s, "count": n}`; finalize as `Σs / Σn`.
+
+Finalizers combine partials linearly. Aliased projection (`SELECT agg(x) AS alias FROM c`): gateway's `rewrittenQuery` rewrites to `VALUE` form; after finalization, the pipeline wraps the scalar back into `{"alias": v}` (alias from `queryInfo.groupByAliasToAggregateType`, which — despite the name — also carries non-grouped aliased aggregates).
+
+Multi-aggregate (`SELECT MIN(x) AS a, MAX(x) AS b`): gateway emits `aggregates: ["Min","Max"]` and a per-partition array of per-aggregate partials in position order. The pipeline carries a parallel state vector.
+
+**Stage 2 — DISTINCT.** Hash key = SHA-256 of canonical JSON (sorted keys, no whitespace) of the projection row. 256-bit keys avoid collision handling and bound memory. Emit on first occurrence, skip on repeat. Same code path handles object DISTINCT and `DISTINCT VALUE` (both are "hash the whole row").
+
+**Stage 3 — ORDER BY single-key.** Min/max-heap over `{partitionIdx, row, orderKey}`. Popping the top pulls the next row from that partition's channel; if the channel is empty *and* the partition has no continuation left, drop it; else block. Comparator uses Cosmos item ordering.
+
+**Stage 4 — TOP.** Wrap upstream: count emitted rows; on reaching `N`, close upstream (cancels outstanding partition goroutines via context).
+
+**Stage 5 — OFFSET / LIMIT.** Same operator as Stage 4 with a `skip` counter before emit. Upstream is always the Stage 3 merger.
+
+**Stage 6 — GROUP BY.** `map[groupKey]*aggState`. `groupKey` = canonical JSON of grouping expressions from `queryInfo.groupByExpressions`. `aggState` = state vector from Stage 1. Drain → emit. Order unspecified (matches Cosmos semantics).
+
+### 5.5 Private helpers the fork touches
+
+Stage 0 is the only stage that reaches beyond `queryengine/internal/gonative/`:
+
+| File | Change |
+|---|---|
+| `cosmos_container_query_engine.go` | In `NewCrossPartitionQueryItemsPager`, default `queryOptions.QueryEngine` to `gonative.Default()` when nil (unless `queryengine.Disabled`). Existing private helpers `getQueryPlanFromGateway` and `getPartitionKeyRangesRaw` are already wired; no new public API. |
+| `cosmos_container.go` | Add `planCache` field to `ContainerClient`; initialize in `NewContainer`. |
+| `cosmos_client_options.go` | Add optional `QueryPlanCacheSize int` (default 256). |
+| `queryengine/cosmos_query_engine.go` | Add `Disabled` sentinel, `ErrUnsupportedPlanFeature` sentinel, helper `JoinFeatures([]Feature) string`. |
+| `CHANGELOG.md` | One entry per stage. |
+
+### 5.6 Failure modes
+
+| Scenario | Behavior |
+|---|---|
+| Plan fetch errors (network / auth / throttle) | Propagate to caller. No fallback — the plan fetch is the first real call. |
+| Plan references a feature not yet implemented | `CreateQueryPipeline` returns `ErrUnsupportedPlanFeature`; pager falls back to raw single-query path (today's behavior; guaranteed no regression). |
+| Partition query errors mid-stream | Cancel other partitions; return wrapped error. No partial results. |
+| Context cancellation | All goroutines exit on next select; pager returns `context.Canceled`. |
+| Gateway 429 on per-partition query | SDK's existing retry policy handles `x-ms-retry-after-ms` at the HTTP layer; partition goroutines retry transparently. |
+
+### 5.7 Explicitly not touched
+
+- `CreateReadManyPipeline` → `return nil, ErrUnsupportedPlanFeature`. Bytebase doesn't use ReadMany; parity goal doesn't cover it.
+- `hasNonStreamingOrderBy` queries (vector/hybrid search scoring) → `ErrUnsupportedPlanFeature`. Not in the target inventory.
+- Upstream contribution to `Azure/azure-sdk-for-go` → follow-up after Stage 6.
+
+## 6. Rollout, operations, risks
+
+### 6.1 Rollout mechanics
+
+Each of the seven stages is a separate PR against the `bytebase/azure-sdk-for-go` fork on integration branch `bytebase/cosmos-query-engine`. Merge to fork `main` once all seven land and the Stage 7 Go-twin harness reports 39/40 against both Azure and the emulator. Bytebase's backend picks up the new SDK via a single `go.mod` bump — no per-stage bumps. That bump is the only Bytebase-side reviewable change; it looks like a routine dependency bump.
+
+Each fork PR adds a CHANGELOG entry under `1.5.0-beta.6 (Unreleased)`, documenting the newly-announced `SupportedFeatures()` value and the operator it enables.
+
+### 6.2 Observability
+
+Reuse the fork's existing `EventQueryEngine` log channel. Three log points, all gated behind that event:
+
+- **Plan fetch** — `{query_hash, cache_hit, features_requested, rtt_ms}`.
+- **Pipeline start** — `{operator_chain, partition_count, query_hash}`.
+- **Partition sub-query** (debug) — `{pk_range_id, continuation_present, rewritten_query}`.
+
+No new metrics surface.
+
+### 6.3 Backward compatibility
+
+- `QueryOptions.QueryEngine == nil` → auto-enable `gonative.Default()`. Existing callers see new behavior on the SDK bump; the change is "queries that used to 400 now succeed."
+- `QueryOptions.QueryEngine = queryengine.Disabled` → preserves today's raw-forward behavior exactly. Escape hatch.
+- All existing public APIs keep their signatures.
+
+### 6.4 Open risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Plan-JSON shape drift | Medium | Decode with unknown-field tolerance; only reject on known-flag unsupported values. |
+| Item-ordering semantics mismatch | Medium | Golden tests: Go output compared row-by-row to .NET harness across every type mix. |
+| Upstream fork divergence on next sync | Low | All engine code in new sub-package; ~20 LOC surface in existing fork files. |
+| Unbounded memory on huge GROUP BY / DISTINCT cardinality | Low / catastrophic | Configurable caps (`MaxGroupCount`, `MaxDistinctCount`, default 1e6); return `ErrCardinalityExceeded`. |
+| Concurrency bugs in partition fan-out | Medium | `errgroup` pattern; race detector in CI; deliberate-latency fake partitions in unit tests. |
+| Plan-cache staleness vs partition splits | Low | Cache stores only `queryInfo`; pk-ranges always fetched fresh. |
+
+### 6.5 Follow-ups (out of scope)
+
+1. Upstream PR to `Azure/azure-sdk-for-go` with `queryengine/internal/gonative/` — separate issue after Stage 6 soaks for a week on Bytebase's staging.
+2. UI hint for composite-index errors (query 4.3 class) — frontend-only PR, separate from BYT-9239.
+3. `ReadManyItems` parity — if Bytebase ever adopts ReadMany.
+4. Remove `backend/plugin/db/cosmosdb/emulator.go` if the engine obsoletes the hand-rolled REST fallback — verify during Stage 7.
+
+### 6.6 Exit criteria
+
+Before the `go.mod` bump merges into Bytebase:
+
+- `scripts/cosmos-repro-dotnet/` and `scripts/cosmos-repro-go/` both report 39/40 PASS on the same Azure container; the one FAIL is 4.3 on both.
+- All fork unit tests pass under `-race` on Linux amd64, Linux arm64, macOS arm64.
+- Integration suite passes in the fork CI against Azure (key from secrets); auto-skipped locally without `AZURE_COSMOS_KEY`.
+- CHANGELOG entry in the fork for `1.5.0-beta.6` summarizes the feature and notes the default-activation behavior change.
+
+## 7. Open concerns from adversarial review (to be resolved in the implementation plan)
+
+An adversarial review (2026-04-22) raised three high-severity concerns against the spec as written. They are not blockers for starting the plan, but each implementation stage must explicitly decide how to address them.
+
+1. **Activation regression risk.** Default-wiring `gonative.Default()` for nil callers turns today's single-call gateway path into a multi-call path (plan fetch + PK-range discovery) before the first row is returned. Transient auth/throttle/network failures on those new calls could break queries that succeed today. The implementation plan should either (a) only engage the engine after the gateway returns the specific unsupported-cross-partition error, or (b) keep the engine opt-in and have Bytebase's driver pass it explicitly. Section 3.2's current "auto-enable" wording is the working hypothesis — the plan must test this assumption before Stage 0 merges.
+
+2. **No operator-level kill switch from Bytebase.** `queryengine.Disabled` is the SDK-side escape hatch, but Bytebase's driver never sets `QueryOptions.QueryEngine`. After the `go.mod` bump, operators can't disable the engine without another code-and-dependency rollout. The plan must add a Bytebase-side config or feature flag (e.g. `BB_COSMOS_DISABLE_QUERY_ENGINE`) that the driver reads and propagates to `QueryOptions.QueryEngine = queryengine.Disabled` when set.
+
+3. **Parity harness is too shallow to catch silent wrong-result bugs.** Stage 7's harness compares PASS/FAIL and row counts only (see `scripts/cosmos-repro-dotnet/Program.cs` — it counts `page.Count`, never serializes rows). That won't catch bad ORDER BY merges, DISTINCT leaks, wrong GROUP BY buckets, or malformed VALUE/aliased aggregate shapes. Stage 7 must be upgraded to canonicalize result payloads (sorted JSON for ordered queries, sorted-by-canonical-key for unordered) and diff .NET vs Go row-by-row. The existing `.NET` harness also needs updating to emit the canonical payload.
+
+## 8. Appendix — reproduction artifacts
+
+- `.NET` harness: `scripts/cosmos-repro-dotnet/` (`Microsoft.Azure.Cosmos 3.47.1`, targets `net10.0`) — produces the `.NET SDK` column of the target inventory.
+- Query inventory and PASS/FAIL matrix: `./target-queries.md`.
+- Raw output logs: logs captured during the reproduction run.

--- a/sdk/data/azcosmos/queryengine/docs/stage-0-plan.md
+++ b/sdk/data/azcosmos/queryengine/docs/stage-0-plan.md
@@ -1,0 +1,802 @@
+# Cosmos Query Engine — Stage 0 Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the plumbing for the pure-Go distributed query engine inside the Bytebase fork of `azcosmos` as a reviewable, zero-behavior-change PR: sentinels, the `gonative` package skeleton with an inert default engine, the plan cache on `ContainerClient`, and a configurable cache size — all without activating the engine yet.
+
+**Architecture:** All changes land in the fork `github.com/bytebase/azure-sdk-for-go/sdk/data/azcosmos`. The new `queryengine/internal/gonative/` sub-package holds the implementation; `queryengine` itself gets two sentinels (`Disabled`, `ErrUnsupportedPlanFeature`). `ContainerClient` gains an LRU plan cache field that is allocated but unused in Stage 0; `ClientOptions` gains a `QueryPlanCacheSize` knob. No change to any public API signature. `NewCrossPartitionQueryItemsPager` is deliberately untouched — activation and fallback are Stage 1 territory.
+
+**Tech Stack:** Go 1.21+; `github.com/hashicorp/golang-lru/v2` (already a transitive dep in Bytebase; fork depends on stdlib only today — we add the LRU dep); standard `testing` + `testify` (already used in the fork's tests).
+
+**Reference spec:** [`docs/superpowers/specs/2026-04-22-cosmos-cross-partition-query-engine-design.md`](../specs/2026-04-22-cosmos-cross-partition-query-engine-design.md)
+
+**Authoritative target query list:** [`./target-queries.md`](./target-queries.md)
+
+---
+
+## Out of scope for Stage 0 (deferred to Stage 1)
+
+- Auto-enabling the engine in `NewCrossPartitionQueryItemsPager`.
+- Engage-on-error activation (the Codex-recommended strategy — chosen for Stage 1).
+- Bytebase-side kill switch (env var propagation to `QueryOptions.QueryEngine = queryengine.Disabled`).
+- Any query-operator logic (aggregates, DISTINCT, etc.).
+- `go.mod` bump in `bytebase/bytebase` (no value until Stage 1 ships a first operator).
+
+## File map
+
+```
+# Fork: github.com/bytebase/azure-sdk-for-go
+sdk/data/azcosmos/
+├── queryengine/
+│   ├── cosmos_query_engine.go          # MODIFY — add Disabled, ErrUnsupportedPlanFeature
+│   ├── cosmos_query_engine_test.go     # CREATE — sentinel tests
+│   └── internal/
+│       └── gonative/                   # CREATE (new sub-package, Go-internal)
+│           ├── doc.go                  # CREATE
+│           ├── engine.go               # CREATE — Default() + inert engine
+│           └── engine_test.go          # CREATE
+├── cosmos_client_options.go            # MODIFY — add QueryPlanCacheSize
+├── cosmos_container.go                 # MODIFY — add planCache field
+├── cosmos_container_plan_cache_test.go # CREATE — plan cache tests
+├── go.mod                              # MODIFY — add golang-lru/v2 dep
+├── go.sum                              # MODIFY — via `go mod tidy`
+└── CHANGELOG.md                        # MODIFY — entry for Stage 0
+```
+
+## Conventions used throughout
+
+- All Go code uses the existing fork's import ordering (stdlib → azure-sdk-core → azcosmos internal → queryengine).
+- Tests use standard `testing` with `require`/`assert` from `github.com/stretchr/testify` — the fork already uses testify per `cosmos_client_retry_policy_test.go` (check that the module has it; if not, add it).
+- Commit messages use the Azure SDK for Go prefix style the fork follows (e.g. `azcosmos: <what>`). One commit per task when the task has a testable deliverable; "prep" tasks may share commits.
+
+---
+
+## Task 1: Prepare fork development environment
+
+**Files:**
+- Clone: `github.com/bytebase/azure-sdk-for-go` → a local working directory the engineer controls
+- Branch: `bytebase/cosmos-query-engine-stage-0`
+
+- [ ] **Step 1: Clone the fork and create a feature branch**
+
+```bash
+# Pick a working directory OUTSIDE the Bytebase repo tree
+cd ~/OpenSource
+git clone git@github.com:bytebase/azure-sdk-for-go.git
+cd azure-sdk-for-go
+git checkout -b bytebase/cosmos-query-engine-stage-0
+```
+
+- [ ] **Step 2: Confirm current test baseline is green on this machine**
+
+Run: `cd sdk/data/azcosmos && go test ./... -count=1`
+Expected: All tests PASS. (Cosmos emulator-dependent tests are guarded by build tags and will skip if no emulator is running; that is fine.)
+
+- [ ] **Step 3: Confirm the branch tracks the upstream fork**
+
+Run: `git status` and `git log --oneline -3`
+Expected: Clean working tree; last commit is `5b89f0889452` (the pseudo-version Bytebase currently pins to) or a descendant.
+
+No commit in this task.
+
+---
+
+## Task 2: Add `Disabled` sentinel to the `queryengine` package
+
+**Files:**
+- Modify: `sdk/data/azcosmos/queryengine/cosmos_query_engine.go`
+- Create: `sdk/data/azcosmos/queryengine/cosmos_query_engine_test.go`
+
+Purpose: provide callers a way to explicitly opt out of the default engine that Stage 1+ will start auto-wiring.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sdk/data/azcosmos/queryengine/cosmos_query_engine_test.go`:
+
+```go
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package queryengine_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisabledIsNonNilSentinel(t *testing.T) {
+	// The Disabled sentinel must be non-nil so callers can distinguish
+	// "no engine specified" (nil) from "explicitly disabled".
+	require.NotNil(t, queryengine.Disabled)
+}
+
+func TestDisabledAdvertisesNoFeatures(t *testing.T) {
+	assert.Equal(t, "", queryengine.Disabled.SupportedFeatures())
+}
+
+func TestDisabledCreateQueryPipelineReturnsUnsupported(t *testing.T) {
+	_, err := queryengine.Disabled.CreateQueryPipeline("SELECT 1", "{}", "{}")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, queryengine.ErrUnsupportedPlanFeature),
+		"Disabled.CreateQueryPipeline should return ErrUnsupportedPlanFeature; got %v", err)
+}
+
+func TestDisabledCreateReadManyPipelineReturnsUnsupported(t *testing.T) {
+	_, err := queryengine.Disabled.CreateReadManyPipeline(nil, "{}", "", 0, nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, queryengine.ErrUnsupportedPlanFeature))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd sdk/data/azcosmos/queryengine && go test -run "^TestDisabled" -count=1 -v`
+Expected: compilation error — `Disabled` and `ErrUnsupportedPlanFeature` undefined.
+
+- [ ] **Step 3: Implement the sentinels**
+
+Edit `sdk/data/azcosmos/queryengine/cosmos_query_engine.go`. Append after the existing `QueryEngine` interface definition:
+
+```go
+// ErrUnsupportedPlanFeature is returned by a QueryEngine implementation when
+// the query plan references a feature the engine has not implemented.
+// Callers receiving this should treat it as "this engine cannot serve this query"
+// and surface the original gateway error if any.
+var ErrUnsupportedPlanFeature = errors.New("azcosmos/queryengine: unsupported plan feature")
+
+// Disabled is a QueryEngine sentinel callers can use to explicitly opt out of
+// any default engine the SDK might install. Every method on Disabled returns
+// ErrUnsupportedPlanFeature.
+var Disabled QueryEngine = disabledEngine{}
+
+type disabledEngine struct{}
+
+func (disabledEngine) SupportedFeatures() string {
+	return ""
+}
+
+func (disabledEngine) CreateQueryPipeline(_ string, _ string, _ string) (QueryPipeline, error) {
+	return nil, ErrUnsupportedPlanFeature
+}
+
+func (disabledEngine) CreateReadManyPipeline(_ []ItemIdentity, _ string, _ string, _ uint8, _ []string) (QueryPipeline, error) {
+	return nil, ErrUnsupportedPlanFeature
+}
+```
+
+Add `"errors"` to the imports at the top of the file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sdk/data/azcosmos/queryengine && go test -run "^TestDisabled" -count=1 -v`
+Expected: all four tests PASS.
+
+- [ ] **Step 5: Run the full package test to guard against unrelated regressions**
+
+Run: `cd sdk/data/azcosmos && go test ./queryengine/... -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sdk/data/azcosmos/queryengine/cosmos_query_engine.go \
+        sdk/data/azcosmos/queryengine/cosmos_query_engine_test.go
+git commit -m "azcosmos: add Disabled sentinel and ErrUnsupportedPlanFeature to queryengine"
+```
+
+---
+
+## Task 3: Create the `gonative` package skeleton
+
+**Files:**
+- Create: `sdk/data/azcosmos/queryengine/internal/gonative/doc.go`
+- Create: `sdk/data/azcosmos/queryengine/internal/gonative/engine.go`
+- Create: `sdk/data/azcosmos/queryengine/internal/gonative/engine_test.go`
+
+Purpose: introduce the package where Stage 1+ operators will live. For Stage 0, the package exposes only `Default()`, which returns an engine that advertises no features and rejects every `CreateQueryPipeline` call with `ErrUnsupportedPlanFeature` — semantically identical to `queryengine.Disabled` today, but a distinct type so later stages can extend it in place.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `sdk/data/azcosmos/queryengine/internal/gonative/engine_test.go`:
+
+```go
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package gonative_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine/internal/gonative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultReturnsNonNilEngine(t *testing.T) {
+	e := gonative.Default()
+	require.NotNil(t, e)
+}
+
+func TestDefaultAdvertisesNoFeaturesAtStage0(t *testing.T) {
+	assert.Equal(t, "", gonative.Default().SupportedFeatures())
+}
+
+func TestDefaultCreateQueryPipelineReturnsUnsupportedAtStage0(t *testing.T) {
+	_, err := gonative.Default().CreateQueryPipeline("SELECT * FROM c", "{}", "{}")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, queryengine.ErrUnsupportedPlanFeature),
+		"Default() should reject all queries at Stage 0; got %v", err)
+}
+
+func TestDefaultCreateReadManyPipelineReturnsUnsupported(t *testing.T) {
+	_, err := gonative.Default().CreateReadManyPipeline(nil, "{}", "", 0, nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, queryengine.ErrUnsupportedPlanFeature))
+}
+
+func TestDefaultReturnsDistinctEngineInstances(t *testing.T) {
+	// Each caller gets its own instance — enables per-engine caches in later stages.
+	a := gonative.Default()
+	b := gonative.Default()
+	assert.NotSame(t, a, b)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd sdk/data/azcosmos && go test ./queryengine/internal/gonative/... -run "^TestDefault" -count=1 -v`
+Expected: compilation error — package `gonative` does not exist.
+
+- [ ] **Step 3: Create the package doc file**
+
+Create `sdk/data/azcosmos/queryengine/internal/gonative/doc.go`:
+
+```go
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package gonative implements queryengine.QueryEngine entirely in Go
+// (no cgo, no native plugins, no external toolchain).
+//
+// It is the default query engine that the azcosmos SDK will auto-wire into
+// cross-partition queries starting at Stage 1 of the BYT-9239 roll-out.
+// In Stage 0 (this package's first release) the engine is inert:
+// SupportedFeatures() returns "" and CreateQueryPipeline returns
+// queryengine.ErrUnsupportedPlanFeature unconditionally.
+package gonative
+```
+
+- [ ] **Step 4: Create the engine implementation**
+
+Create `sdk/data/azcosmos/queryengine/internal/gonative/engine.go`:
+
+```go
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package gonative
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+)
+
+// Engine is the pure-Go implementation of queryengine.QueryEngine.
+// It is constructed by Default(); callers should not instantiate Engine
+// directly because future stages may add required initialization.
+type Engine struct {
+	// (future stages add fields: supportedFeatures set, cardinality caps, etc.)
+}
+
+// Default returns a new Engine with Stage-0 capabilities (none).
+// Callers should treat the returned value as opaque.
+func Default() *Engine {
+	return &Engine{}
+}
+
+// SupportedFeatures implements queryengine.QueryEngine.
+func (e *Engine) SupportedFeatures() string {
+	// Stage 0: advertise no features. Stage 1 appends "Aggregate", etc.
+	return ""
+}
+
+// CreateQueryPipeline implements queryengine.QueryEngine.
+func (e *Engine) CreateQueryPipeline(_ string, _ string, _ string) (queryengine.QueryPipeline, error) {
+	// Stage 0: every query plan is unsupported.
+	return nil, queryengine.ErrUnsupportedPlanFeature
+}
+
+// CreateReadManyPipeline implements queryengine.QueryEngine.
+func (e *Engine) CreateReadManyPipeline(_ []queryengine.ItemIdentity, _ string, _ string, _ uint8, _ []string) (queryengine.QueryPipeline, error) {
+	return nil, queryengine.ErrUnsupportedPlanFeature
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd sdk/data/azcosmos && go test ./queryengine/internal/gonative/... -count=1 -v`
+Expected: all five tests PASS.
+
+- [ ] **Step 6: Verify the engine satisfies the interface at compile time**
+
+Add an interface-conformance assertion. Edit `sdk/data/azcosmos/queryengine/internal/gonative/engine.go`, immediately after the `Engine` struct definition:
+
+```go
+// Compile-time check that *Engine satisfies the interface.
+var _ queryengine.QueryEngine = (*Engine)(nil)
+```
+
+Run: `cd sdk/data/azcosmos && go build ./queryengine/internal/gonative/...`
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sdk/data/azcosmos/queryengine/internal/gonative/
+git commit -m "azcosmos: add gonative package with inert Default engine"
+```
+
+---
+
+## Task 4: Add `golang-lru/v2` dependency to the fork
+
+**Files:**
+- Modify: `sdk/data/azcosmos/go.mod`
+- Modify: `sdk/data/azcosmos/go.sum`
+
+Purpose: Tasks 5 and 6 need an LRU cache. `hashicorp/golang-lru/v2` is the de facto choice and is already in Bytebase's transitive deps (`go.mod:60`: `github.com/hashicorp/golang-lru/v2 v2.0.7`); using it in the fork keeps the downstream dep graph flat.
+
+- [ ] **Step 1: Add the require directive**
+
+Run: `cd sdk/data/azcosmos && go get github.com/hashicorp/golang-lru/v2@v2.0.7`
+Expected: `go.mod` gets a new `require github.com/hashicorp/golang-lru/v2 v2.0.7` line; `go.sum` updates.
+
+- [ ] **Step 2: Tidy the module**
+
+Run: `cd sdk/data/azcosmos && go mod tidy`
+Expected: no further changes (single-dep add).
+
+- [ ] **Step 3: Verify the module still builds**
+
+Run: `cd sdk/data/azcosmos && go build ./...`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sdk/data/azcosmos/go.mod sdk/data/azcosmos/go.sum
+git commit -m "azcosmos: add hashicorp/golang-lru/v2 v2.0.7 dependency"
+```
+
+---
+
+## Task 5: Add `QueryPlanCacheSize` option to `ClientOptions`
+
+**Files:**
+- Modify: `sdk/data/azcosmos/cosmos_client_options.go`
+- Modify: `sdk/data/azcosmos/cosmos_client_options_test.go` (create if it does not exist — verify with `ls` first)
+
+Purpose: expose a per-client knob for the plan cache size so operators with large query libraries can raise it (or set to 0 to disable caching entirely in Stage 1+).
+
+- [ ] **Step 1: Write the failing test**
+
+First, check whether `cosmos_client_options_test.go` already exists:
+
+Run: `ls sdk/data/azcosmos/cosmos_client_options_test.go 2>/dev/null || echo MISSING`
+
+If MISSING, create the file; otherwise, append.
+
+Add this test function to `sdk/data/azcosmos/cosmos_client_options_test.go`:
+
+```go
+func TestQueryPlanCacheSizeDefaultsToSensibleValue(t *testing.T) {
+	var o azcosmos.ClientOptions
+	// Zero value is the Go default; the SDK treats zero as "use the built-in default".
+	// The built-in default is not user-facing, but it must be > 0 so caching is on by default.
+	assert.Equal(t, 0, o.QueryPlanCacheSize,
+		"zero value should map to the SDK default; the field itself stores zero")
+}
+
+func TestQueryPlanCacheSizeIsSettable(t *testing.T) {
+	o := azcosmos.ClientOptions{QueryPlanCacheSize: 512}
+	assert.Equal(t, 512, o.QueryPlanCacheSize)
+}
+
+func TestQueryPlanCacheSizeNegativeIsAllowed(t *testing.T) {
+	// Interpretation of negative values is documented as "disabled".
+	o := azcosmos.ClientOptions{QueryPlanCacheSize: -1}
+	assert.Equal(t, -1, o.QueryPlanCacheSize)
+}
+```
+
+If you created the file, add a package declaration and imports:
+
+```go
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos_test
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+	"github.com/stretchr/testify/assert"
+)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd sdk/data/azcosmos && go test -run "^TestQueryPlanCacheSize" -count=1 -v`
+Expected: compilation error — `QueryPlanCacheSize` undefined on `ClientOptions`.
+
+- [ ] **Step 3: Add the field**
+
+In `sdk/data/azcosmos/cosmos_client_options.go`, find the `ClientOptions` struct and add:
+
+```go
+	// QueryPlanCacheSize bounds the per-client LRU cache of Cosmos query plans.
+	// Zero (the default) uses the SDK default (256 entries).
+	// Negative values disable the cache entirely.
+	QueryPlanCacheSize int
+```
+
+Place it at the end of the struct body, directly before the closing brace, with a blank line separating it from the prior field.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sdk/data/azcosmos && go test -run "^TestQueryPlanCacheSize" -count=1 -v`
+Expected: all three tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/data/azcosmos/cosmos_client_options.go sdk/data/azcosmos/cosmos_client_options_test.go
+git commit -m "azcosmos: add QueryPlanCacheSize option to ClientOptions"
+```
+
+---
+
+## Task 6: Add `planCache` field to `ContainerClient` with LRU init
+
+**Files:**
+- Modify: `sdk/data/azcosmos/cosmos_container.go`
+- Create: `sdk/data/azcosmos/cosmos_container_plan_cache_test.go`
+
+Purpose: the per-container LRU cache that Stage 1+ uses to amortize `getQueryPlanFromGateway` costs. Allocated here; unused this stage.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `sdk/data/azcosmos/cosmos_container_plan_cache_test.go`:
+
+```go
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+// Tests in this file are in-package (not _test package) because planCache is
+// intentionally unexported — only other files in this package need to see it.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerPlanCacheAllocatedWithDefaultSize(t *testing.T) {
+	c := newTestContainer(t, 0) // 0 -> SDK default
+	require.NotNil(t, c.planCache)
+	assert.Equal(t, 256, c.planCache.Size())
+}
+
+func TestContainerPlanCacheRespectsExplicitSize(t *testing.T) {
+	c := newTestContainer(t, 64)
+	require.NotNil(t, c.planCache)
+	assert.Equal(t, 64, c.planCache.Size())
+}
+
+func TestContainerPlanCacheDisabledByNegativeSize(t *testing.T) {
+	c := newTestContainer(t, -1)
+	assert.Nil(t, c.planCache, "negative size should disable the cache entirely")
+}
+
+func TestContainerPlanCacheRoundTrip(t *testing.T) {
+	c := newTestContainer(t, 4)
+	key := planCacheKey{
+		databaseID:      "db",
+		containerID:     "coll",
+		normalizedQuery: "SELECT 1",
+		features:        "",
+	}
+	payload := []byte(`{"partitionedQueryExecutionInfoVersion":2}`)
+	c.planCache.Add(key, payload)
+	got, ok := c.planCache.Get(key)
+	require.True(t, ok)
+	assert.Equal(t, payload, got)
+}
+
+// newTestContainer constructs a minimal ContainerClient sufficient for cache
+// tests; it does not make network calls.
+func newTestContainer(t *testing.T, cacheSize int) *ContainerClient {
+	t.Helper()
+	return &ContainerClient{
+		link:      "dbs/db/colls/coll",
+		planCache: newPlanCache(cacheSize),
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd sdk/data/azcosmos && go test -run "^TestContainerPlanCache" -count=1 -v`
+Expected: compilation error — `planCache`, `planCacheKey`, `newPlanCache` undefined.
+
+- [ ] **Step 3: Implement the cache type and key**
+
+At the top of `sdk/data/azcosmos/cosmos_container.go`, add to the imports:
+
+```go
+	lru "github.com/hashicorp/golang-lru/v2"
+```
+
+Below the `ContainerClient` struct declaration (after the closing `}`), add:
+
+```go
+// defaultQueryPlanCacheSize is the cache size used when
+// ClientOptions.QueryPlanCacheSize is zero.
+const defaultQueryPlanCacheSize = 256
+
+// planCacheKey uniquely identifies a cached query plan within a container.
+// The `features` component is part of the key because the same query text
+// produces different plans depending on the features the engine advertises.
+type planCacheKey struct {
+	databaseID      string
+	containerID     string
+	normalizedQuery string
+	features        string
+}
+
+// newPlanCache returns an initialized LRU cache for query plans, or nil if
+// the caller asked for caching to be disabled (negative size).
+func newPlanCache(size int) *lru.Cache[planCacheKey, []byte] {
+	switch {
+	case size < 0:
+		return nil
+	case size == 0:
+		size = defaultQueryPlanCacheSize
+	}
+	// lru.New returns an error only when size <= 0, which we have ruled out.
+	c, err := lru.New[planCacheKey, []byte](size)
+	if err != nil {
+		// Should be unreachable.
+		panic(err)
+	}
+	return c
+}
+```
+
+Add a field to the `ContainerClient` struct:
+
+```go
+	planCache *lru.Cache[planCacheKey, []byte]
+```
+
+Place it after the existing fields, with no blank line separator.
+
+**Wiring the cache size through the client.** The fork's `Client` struct (`cosmos_client.go`) does **not** currently store `ClientOptions` — `NewClientWithKey` and `NewClient` destructure the options into a pipeline and discard the struct. We need to thread just the one value we care about. Do this in two edits:
+
+1. In `sdk/data/azcosmos/cosmos_client.go`, add a field to the `Client` struct:
+
+```go
+type Client struct {
+    endpoint    string
+    internal    *azcore.Client
+    gem         *globalEndpointManager
+    endpointUrl *url.URL
+
+    queryPlanCacheSize int
+}
+```
+
+Then populate it at the end of `NewClientWithKey` (currently returns `&Client{endpoint: endpoint, endpointUrl: endpointUrl, internal: internalClient, gem: gem}, nil`):
+
+```go
+client := &Client{endpoint: endpoint, endpointUrl: endpointUrl, internal: internalClient, gem: gem}
+if o != nil {
+    client.queryPlanCacheSize = o.QueryPlanCacheSize
+}
+return client, nil
+```
+
+Do the same for `NewClient` (the token-credential variant). Search for the other `&Client{...}` literal and apply the same pattern.
+
+2. In `sdk/data/azcosmos/cosmos_container.go`, update `newContainer` (currently 3 lines) to include the cache:
+
+```go
+func newContainer(id string, database *DatabaseClient) (*ContainerClient, error) {
+    return &ContainerClient{
+        id:        id,
+        database:  database,
+        link:      createLink(database.link, pathSegmentCollection, id),
+        planCache: newPlanCache(database.client.queryPlanCacheSize),
+    }, nil
+}
+```
+
+`database.client` reaches the parent `*Client`; the field name is `client` per the existing `DatabaseClient` definition.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sdk/data/azcosmos && go test -run "^TestContainerPlanCache" -count=1 -v`
+Expected: all four tests PASS.
+
+- [ ] **Step 5: Run the full package test suite to check for regressions**
+
+Run: `cd sdk/data/azcosmos && go test ./... -count=1`
+Expected: PASS. (Emulator-dependent tests skip when the emulator is unreachable — that is fine.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sdk/data/azcosmos/cosmos_container.go \
+        sdk/data/azcosmos/cosmos_container_plan_cache_test.go
+git commit -m "azcosmos: add per-container LRU plan cache (allocated, unused in Stage 0)"
+```
+
+---
+
+## Task 7: Update `CHANGELOG.md`
+
+**Files:**
+- Modify: `sdk/data/azcosmos/CHANGELOG.md`
+
+- [ ] **Step 1: Add a CHANGELOG entry under `1.5.0-beta.6 (Unreleased)`**
+
+At the top of the file, find the `## 1.5.0-beta.6 (Unreleased)` section. Under `### Other Changes` (if present, else under `### Features Added`), append:
+
+```markdown
+* Added `queryengine.Disabled` sentinel and `queryengine.ErrUnsupportedPlanFeature` error, plus a new `queryengine/internal/gonative` sub-package housing the pure-Go query engine that later stages will flesh out. No behavior change in Stage 0 — the engine is inert and not yet auto-enabled. See BYT-9239.
+* Added `ClientOptions.QueryPlanCacheSize` and a per-container LRU plan cache; unused in Stage 0.
+```
+
+- [ ] **Step 2: Verify markdown renders cleanly**
+
+Run: `grep -n "^##" sdk/data/azcosmos/CHANGELOG.md | head`
+Expected: the `## 1.5.0-beta.6 (Unreleased)` header still sits at the top and is well-formed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sdk/data/azcosmos/CHANGELOG.md
+git commit -m "azcosmos: changelog entry for queryengine Stage 0 plumbing"
+```
+
+---
+
+## Task 8: Integration smoke test — fork still works end-to-end
+
+**Files:**
+- None new; this task is verification-only.
+
+Purpose: make sure none of the above changes regressed the fork's existing tests, including the emulator-dependent ones if the emulator is reachable.
+
+- [ ] **Step 1: Run the full fork test suite with the race detector**
+
+Run: `cd sdk/data/azcosmos && go test -race ./... -count=1`
+Expected: PASS (emulator tests may skip).
+
+- [ ] **Step 2: If a Cosmos emulator is running locally, confirm emulator tests pick it up**
+
+Check: `docker ps --filter name=cosmosdb --format '{{.Names}}'`
+
+If the container is up, the emulator tests (files named `emulator_*_test.go`, e.g. `emulator_cosmos_container_test.go`) detect it automatically through the `newEmulatorTests(t)` helper and run inline with the Step 1 invocation. No separate command or build tag is needed — just re-read the Step 1 output and confirm that tests with names like `TestContainerCRUD` are not marked SKIP.
+
+If the container is not up, those tests skip themselves. That is acceptable — the fork's CI runs the emulator separately.
+
+- [ ] **Step 3: Confirm the engineered-in interface conformance still holds**
+
+Run: `cd sdk/data/azcosmos && go vet ./...`
+Expected: no diagnostics.
+
+No commit in this task.
+
+---
+
+## Task 9: Push the fork branch and capture the pseudo-version for future use
+
+**Files:**
+- None in the repo; the deliverable is a pushed branch + a recorded pseudo-version string.
+
+Purpose: Stage 1 and beyond will bump Bytebase's `go.mod` to this new pseudo-version. Record it now so future stages have a concrete anchor.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin bytebase/cosmos-query-engine-stage-0`
+Expected: branch pushed; GitHub print-out of the PR-creation URL.
+
+- [ ] **Step 2: Open a pull request on the fork**
+
+Run:
+```bash
+gh pr create \
+  --title "azcosmos: Stage 0 — query engine plumbing (BYT-9239)" \
+  --body "$(cat <<'EOF'
+Part 1 of 7 for BYT-9239. This PR adds the sentinels, the `gonative` package skeleton,
+the per-container plan cache, and the `QueryPlanCacheSize` option. No behavior change —
+the engine is inert and not yet auto-enabled. See the spec for full context:
+`docs/superpowers/specs/2026-04-22-cosmos-cross-partition-query-engine-design.md` in the
+Bytebase repo.
+
+## Test plan
+- [x] `go test -race ./sdk/data/azcosmos/... -count=1`
+- [x] `go vet ./sdk/data/azcosmos/...`
+- [ ] Reviewer: sanity-check CHANGELOG entry and confirm no public API signature changed.
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 3: Record the head commit SHA for later go.mod bumps**
+
+Run:
+```bash
+git rev-parse HEAD | head -c 12
+```
+
+Paste the 12-char prefix (e.g. `a1b2c3d4e5f6`) and the UTC commit timestamp into a scratch note for Stage 1:
+
+Run: `git show -s --format='%cI %H' HEAD`
+Expected: a UTC ISO timestamp followed by the full SHA.
+
+The resulting `go.mod` pseudo-version for Stage 1+ will look like:
+`v0.0.0-<timestamp compacted to YYYYMMDDhhmmss>-<12-char-SHA>`.
+
+No commit in this task.
+
+---
+
+## Self-review checklist (run before handing the plan off to execution)
+
+Each check runs against the rendered plan file.
+
+- [ ] **Spec coverage.** The spec's Section 3.1 (package layout) maps to Tasks 3, 5, 6. Section 3.2 (activation) is deferred to Stage 1 and explicitly called out in the "Out of scope" block. Section 3.3 (data flow) has no Stage 0 work. Section 3.4 (memory / streaming) applies to operators — Stage 1+. Section 3.5 (error handling) — sentinels are delivered. Section 4 Stage 0 description — covered.
+
+- [ ] **Placeholder scan.** No "TBD", no "TODO", no "similar to", no unshown code inside steps that change code.
+
+- [ ] **Type / identifier consistency.**
+  - Sentinel name: `Disabled` (Task 2) — reused in Task 3 test imports.
+  - Error name: `ErrUnsupportedPlanFeature` (Task 2) — reused in Tasks 2 and 3.
+  - Constructor: `gonative.Default()` (Task 3) — reused in Task 3 tests.
+  - Cache key struct: `planCacheKey` with fields `databaseID, containerID, normalizedQuery, features` (Task 6) — the spec uses the same field names in §3.2 and §5.1.
+  - Cache size constant: `defaultQueryPlanCacheSize = 256` (Task 6) — matches spec §5.1.
+  - Field on `ContainerClient`: `planCache *lru.Cache[planCacheKey, []byte]` (Task 6) — matches spec §5.5.
+
+- [ ] **Path correctness.** All fork paths start with `sdk/data/azcosmos/`; the Bytebase plan doc lives under `docs/superpowers/plans/` per the writing-plans skill default.
+
+- [ ] **Granularity.** Each step is a 2–5 minute action; every code change is fully shown; every test precedes its implementation.
+
+- [ ] **Out-of-scope is explicit.** The Stage 0 plan explicitly defers Stage 1 activation, engage-on-error, and the Bytebase kill switch, so later plans won't get lost.
+
+---
+
+## What Stage 1 depends on from Stage 0
+
+Bookmarks for the Stage 1 author:
+
+1. `queryengine.Disabled` — Stage 1 uses this when the Bytebase env var opts out.
+2. `queryengine.ErrUnsupportedPlanFeature` — Stage 1's aggregate operator returns this if a plan sneaks an unsupported aggregate past `SupportedFeatures()`.
+3. `gonative.Default()` — Stage 1 extends the `Engine` struct with aggregate support; the constructor signature stays stable.
+4. `ContainerClient.planCache` — Stage 1 fills it.
+5. `ClientOptions.QueryPlanCacheSize` — Stage 1 reads it at client build time (already done).
+6. Stage 0 head commit SHA (from Task 9) — Stage 1 bumps Bytebase `go.mod` past this point once Stage 1's own commits are pushed.
+
+---

--- a/sdk/data/azcosmos/queryengine/docs/target-queries.md
+++ b/sdk/data/azcosmos/queryengine/docs/target-queries.md
@@ -1,0 +1,199 @@
+# BYT-9239 — Cosmos DB Query Parsing / Cross-Partition Investigation
+
+## Context
+
+Linear issue BYT-9239 reports that Bytebase's Cosmos DB SQL viewer fails on several query types with cross-partition errors. The attached functional test plan (`Bytebase-Cosmos-Parsing.pdf`) ran 13 feature areas against a `WorldCities` container; many queries fail at the gateway with:
+
+> "The provided cross partition query can not be directly served by the gateway. This is a first chance (internal) exception that all newer clients will know how to handle gracefully... but unless you see it bubble up as an exception (which only happens on older SDK clients), then you can safely ignore this message."
+
+Aggregates additionally fail with: *"Cross partition query only supports 'VALUE \<AggregateFunc\>' for aggregates."*
+
+This points at the Bytebase Cosmos driver using an older/gateway-mode SDK path that does not transparently handle cross-partition queries (TOP, ORDER BY, aggregates, GROUP BY, DISTINCT, OFFSET/LIMIT).
+
+## Query Inventory from PDF
+
+> **.NET SDK column**: measured by running each query against the same Azure account (`bytebase-cosmostest` → `testdb` → `WorldCities`, partition key `/country`) via the Microsoft .NET SDK `Microsoft.Azure.Cosmos` v3.47.1 (harness: `scripts/cosmos-repro-dotnet/`). Results are identical in both `ConnectionMode.Gateway` and `ConnectionMode.Direct`, so a single column is shown.
+
+### 1. Basic SELECT
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 1.1 | `SELECT * FROM c` | Success | PASS (18 rows) | — |
+| 1.2 | `SELECT c.id, c.name, c.country, c.population FROM c` | Success | PASS (18 rows) | — |
+| 1.3 | `SELECT TOP 10 * FROM c` | **Failed** (cross-partition) | PASS (10 rows) | — |
+
+### 2. Filtering — WHERE Clause
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 2.1 | `SELECT * FROM c WHERE c.country = "AE"` | Success | PASS (5 rows) | — |
+| 2.2 | `SELECT * FROM c WHERE c._ts > 1743702439` | Success | PASS (18 rows) | — |
+| 2.3 | `SELECT * FROM c WHERE c._ts >= 1743702439` | Success | PASS (18 rows) | — |
+| 2.4 | `SELECT * FROM c WHERE c.country = "AE" OR c.country = "AD"` | Success | PASS (8 rows) | — |
+| 2.5 | `SELECT * FROM c WHERE c.country IN ("AE", "US", "GB", "AD")` | Success | PASS (15 rows) | — |
+| 2.6 | `SELECT * FROM c WHERE CONTAINS(c.name, "Fujayrah")` | Success | PASS (1 row) | — |
+| 2.7 | `SELECT * FROM c WHERE STARTSWITH(c.name, "Al")` | Success | PASS (1 row) | — |
+| 2.8 | `SELECT * FROM c WHERE c.countryRegion != "4"` | Success | PASS (11 rows) | — |
+| 2.9 | `SELECT * FROM c WHERE STRINGTONUMBER(c.population) BETWEEN 10000 AND 100000` | Success | PASS (2 rows) | — |
+
+### 3. Projection & Aliasing
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 3.1 | `SELECT c.name AS cityName, c.country AS countryCode, c.population AS pop FROM c` | Success | PASS (18 rows) | — |
+| 3.2 | `SELECT c.name, c.population, STRINGTONUMBER(c.population) / 1000 AS populationInThousands FROM c` | Success | PASS (18 rows) | — |
+| 3.3 | `SELECT CONCAT(c.name, " (", c.country, ")") AS label FROM c` | Success | PASS (18 rows) | — |
+
+### 4. Sorting — ORDER BY
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 4.1 | `SELECT c.name, c.population FROM c ORDER BY c.population ASC` | **Failed** (cross-partition) | PASS (18 rows) | — |
+| 4.2 | `SELECT c.name, c.population FROM c ORDER BY c.population DESC` | **Failed** (cross-partition) | PASS (18 rows) | — |
+| 4.3 | `SELECT c.country, c.name, c.population FROM c ORDER BY c.country ASC, c.population DESC` | **Failed** (cross-partition) | **FAIL** | Server-side 400 BadRequest: *"The order by query does not have a corresponding composite index that it can be served from."* Multi-key ORDER BY requires a Cosmos composite index on `(country ASC, population DESC)` to be provisioned on the container. This is a real server constraint that affects every SDK, not an SDK limitation. |
+
+### 5. Aggregation
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 5.1 | `SELECT COUNT(1) AS totalRecords FROM c` | **Failed** (must use VALUE) | PASS (1 row) | — |
+| 5.1b | `SELECT VALUE COUNT(1) FROM c` | **Failed** (cross-partition) | PASS (1 row) | — |
+| 5.2 | `SELECT COUNT(1) AS aeCount FROM c WHERE c.country = "AE"` | **Failed** (must use VALUE) | PASS (1 row) | — |
+| 5.2b | `SELECT VALUE COUNT(1) FROM c WHERE c.country = "AE"` | **Failed** (cross-partition) | PASS (1 row) | — |
+| 5.3 | `SELECT SUM(STRINGTONUMBER(c.population)) AS totalPop FROM c` | **Failed** (must use VALUE) | PASS (1 row) | — |
+| 5.3b | `SELECT VALUE SUM(STRINGTONUMBER(c.population)) FROM c` | **Failed** (cross-partition) | PASS (1 row) | — |
+| 5.4 | `SELECT AVG(STRINGTONUMBER(c.population)) AS avgPop FROM c` | **Failed** (must use VALUE) | PASS (1 row) | — |
+| 5.4b | `SELECT VALUE AVG(STRINGTONUMBER(c.population)) FROM c` | **Failed** (cross-partition) | PASS (1 row) | — |
+| 5.5 | `SELECT MIN(...) AS minPop, MAX(...) AS maxPop FROM c WHERE StringToNumber(c.population) > 0` | **Failed** (multi-agg not allowed) | PASS (1 row) | — |
+
+### 6. GROUP BY
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 6.1 | `SELECT c.country, COUNT(1) AS cityCount FROM c GROUP BY c.country` | **Failed** (cross-partition) | PASS (6 rows) | — |
+| 6.2 | `SELECT c.countryRegion, COUNT(1) AS count, SUM(StringToNumber(c.population)) AS totalPop FROM c GROUP BY c.countryRegion` | **Failed** (cross-partition) | PASS (6 rows) | — |
+
+### 7. Built-in Functions — String
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 7.1 | `SELECT UPPER(c.name) AS upperName, LOWER(c.country) AS lowerCountry, LENGTH(c.name) AS nameLen FROM c` | Success | PASS (18 rows) | — |
+
+### 8. Built-in Functions — Math
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 8.1 | `SELECT c.name, ROUND(StringToNumber(c.latitude)) AS lat, ROUND(StringToNumber(c.longitude)) AS lon FROM c` | Success | PASS (18 rows) | — |
+
+### 9. Built-in Functions — Type Checking
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 9.1 | `SELECT c.name, IS_STRING(c.name) AS isStr, IS_NUMBER(c.population) AS isNum FROM c` | Success | PASS (18 rows) | — |
+| 9.2 | `SELECT c.id, IS_DEFINED(c.region) AS hasRegion, IS_NULL(c.code) AS codeNull FROM c` | Success | PASS (18 rows) | — |
+
+### 10. DISTINCT
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 10.1 | `SELECT DISTINCT c.country FROM c` | **Failed** (cross-partition) | PASS (6 rows) | — |
+| 10.2 | `SELECT DISTINCT VALUE c.countryRegion FROM c` | **Failed** (cross-partition) | PASS (6 rows) | — |
+
+### 11. VALUE Keyword
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 11.1 | `SELECT VALUE c.name FROM c WHERE c.country = "AE"` | Success | PASS (5 rows) | — |
+| 11.2 | `SELECT VALUE COUNT(1) FROM c` | **Failed** (scalar aggregate, cross-partition) | PASS (1 row) | — |
+
+### 12. Pagination — OFFSET / LIMIT
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 12.1 | `SELECT * FROM c ORDER BY c.name OFFSET 0 LIMIT 10` | **Failed** (cross-partition) | PASS (10 rows) | — |
+| 12.2 | `SELECT * FROM c ORDER BY c.name OFFSET 10 LIMIT 10` | **Failed** (cross-partition) | PASS (8 rows) | — |
+
+### 13. Geo-spatial
+| # | Query | Go fork (PDF) | .NET SDK | .NET Failure Reason |
+|---|-------|--------|---------|---------------------|
+| 13.1 | `SELECT c.name, ST_DISTANCE({"type":"Point","coordinates":[StringToNumber(c.longitude), StringToNumber(c.latitude)]}, {"type":"Point","coordinates":[55.2708, 25.2048]}) AS distFromDubaiInMeters FROM c` | Success | PASS (18 rows) | — |
+
+## Summary
+
+| Feature Area | Go fork (PDF) | .NET SDK | Notes |
+|---|---|---|---|
+| 1. Basic SELECT | PARTIAL | PASS (3/3) | Go fails on `TOP`; .NET passes all |
+| 2. WHERE Filtering | GOOD | PASS (9/9) | Both handle single-partition queries fine |
+| 3. Projection & Aliasing | GOOD | PASS (3/3) | — |
+| 4. ORDER BY | FAIL | PARTIAL (2/3) | .NET passes single-key ORDER BY; 4.3 multi-key fails on both SDKs because the container lacks a composite index on `(country ASC, population DESC)` — server constraint, not SDK |
+| 5. Aggregation | FAIL | PASS (9/9) | .NET transparently supports aliased and `VALUE` aggregates, single and multi-agg |
+| 6. GROUP BY | FAIL | PASS (2/2) | — |
+| 7. String Functions | GOOD | PASS (1/1) | — |
+| 8. Math Functions | GOOD | PASS (1/1) | — |
+| 9. Type Checking | GOOD | PASS (2/2) | — |
+| 10. DISTINCT | FAIL | PASS (2/2) | .NET handles both `DISTINCT` and `DISTINCT VALUE` |
+| 11. VALUE Keyword | PARTIAL | PASS (2/2) | .NET handles scalar and scalar-aggregate forms |
+| 12. OFFSET / LIMIT | FAIL | PASS (2/2) | .NET handles pagination across partitions |
+| 13. Geo-spatial | GOOD | PASS (1/1) | — |
+
+**Bottom line:** 39/40 queries PASS on the .NET SDK; the single .NET failure (4.3) is a server-side composite-index requirement that affects every SDK. All failures attributed to "older SDK clients" in the PDF — i.e. anything involving cross-partition orchestration (TOP, ORDER BY, aggregates, GROUP BY, DISTINCT, OFFSET/LIMIT, scalar VALUE aggregates) — succeed transparently on the .NET SDK. The root cause of BYT-9239 is that `azcosmos` (Go) lacks the client-side distributed query engine that the .NET/Java/Python/JS SDKs ship; syncing the fork with upstream does not help because the upstream SDK itself does not implement it.
+
+## Current Bytebase Cosmos Driver (Phase 1 Findings)
+
+### SDK versions
+
+| Side | Package | Version | Notes |
+|---|---|---|---|
+| Bytebase (Go) | `github.com/bytebase/azure-sdk-for-go/sdk/data/azcosmos` (fork, replaces upstream `v1.4.2`) | pseudo-version `v0.0.0-20260414094732-5b89f0889452` | Commit `5b89f0889452` at 2026-04-14; CHANGELOG positions this on the upstream `1.5.0-beta.6 (Unreleased)` branch, just past `1.5.0-beta.5 (2026-03-09)` |
+| Reproduction harness (.NET) | `Microsoft.Azure.Cosmos` (NuGet) | **3.47.1** | Targets `net10.0`; host runs .NET SDK 10.0.106 installed via Homebrew |
+
+### Driver behavior
+
+- **Driver**: [backend/plugin/db/cosmosdb/cosmosdb.go](backend/plugin/db/cosmosdb/cosmosdb.go)
+  - Query path: [cosmosdb.go:146](backend/plugin/db/cosmosdb/cosmosdb.go:146) `QueryConn` → `container.NewCrossPartitionQueryItemsPager(statement, queryOption)` at [cosmosdb.go:172](backend/plugin/db/cosmosdb/cosmosdb.go:172)
+  - Only `PageSizeHint` is set; no consistency level, no direct-mode opts, no partition-key hint
+  - Uses SDK default connection (gateway mode)
+- **Query engine gap** — the Go fork *does* expose a `queryengine.QueryEngine` interface on `QueryOptions.QueryEngine` (preview, not-for-production per the SDK doc comment). Bytebase's driver does **not** set it, and Microsoft's reference implementation (`azcosmoscx`, Rust-based) is **not imported**. So the cross-partition orchestration hook exists but is wired to `nil` — the SDK just forwards queries to the gateway and returns whatever the gateway says.
+- **User report**: forked SDK synced with upstream — problem persists. Confirmed root cause: the Go SDK lacks a production client-side distributed query engine (interface only); a sync does not change that. The .NET SDK ships a working one in-box, which is why the .NET reproduction passes 39/40 queries.
+
+## Available Test Targets (verified)
+
+| Target | State | Notes |
+|---|---|---|
+| Local emulator (Docker `cosmosdb`) | Running | vnext Rust gateway, HTTP on `127.0.0.1:8081`, explorer on `1234`, 5 partitions, uses emulator master key |
+| Azure `bytebase-cosmostest` | Live | DB `testdb`, container `WorldCities`, partition key `/country` — matches the PDF schema; cross-partition queries will trigger the same failures |
+
+## .NET Reproduction Plan
+
+### Why .NET
+Microsoft's flagship Cosmos DB SDK is `Microsoft.Azure.Cosmos` (C# / .NET). It is the reference implementation — if queries that fail on the Go fork succeed on .NET, the root cause is Go-SDK-side (gateway codepath / lack of cross-partition orchestration); if .NET also fails, it's server/gateway-level and will need a different fix (e.g., require partition-key filter, surface better error).
+
+### Scope
+Replay the **failing** queries from the PDF (the PASS groups don't need re-validation):
+
+- Basic SELECT (TOP only)
+- ORDER BY (×3)
+- Aggregation with and without `VALUE` (×9 incl. MIN/MAX multi-agg)
+- GROUP BY (×2)
+- DISTINCT (×2)
+- VALUE scalar aggregate (×1)
+- OFFSET/LIMIT (×2)
+
+For each query record: `{ success, row_count | error, elapsed_ms, mode }` where `mode ∈ {Gateway, Direct}`.
+
+### Approach
+
+1. **Host setup** — install .NET SDK via Homebrew: `brew install --cask dotnet-sdk`. Verify with `dotnet --version`.
+2. **Project** — create `scripts/cosmos-repro-dotnet/` (throwaway), `dotnet new console`, add package `Microsoft.Azure.Cosmos` (latest stable, currently 3.47.x).
+3. **Test harness** — single `Program.cs` that:
+   - Reads endpoint / key / db / container / connection-mode from env vars
+   - Defines the ~19 failing queries as a list
+   - For each query and each `ConnectionMode` ∈ `{Gateway, Direct}`:
+     - `container.GetItemQueryIterator<JsonElement>(sql, requestOptions: new QueryRequestOptions { MaxItemCount = 1000 })`
+     - Drain pages, capture row count or exception message
+   - Print a markdown table identical in shape to the PDF summary
+4. **Target** — Azure `bytebase-cosmostest` → `testdb` → `WorldCities` (already provisioned, `/country` PK). Auth via master key retrieved with `az cosmosdb keys list`.
+5. **Compare** — cross-reference .NET results with the PDF's Go-SDK results. Identify which queries succeed in .NET but fail in Go → that is the Bytebase-actionable set. Any queries failing in both point to gateway-level constraints unrelated to SDK choice.
+
+### Critical files to author (outside plan mode)
+- `scripts/cosmos-repro-dotnet/CosmosRepro.csproj`
+- `scripts/cosmos-repro-dotnet/Program.cs`
+- `scripts/cosmos-repro-dotnet/README.md` (how to run against emulator / Azure)
+
+### Verification
+- `dotnet run -- --mode gateway`
+- `dotnet run -- --mode direct`
+- Produce a side-by-side Go-fork-vs-.NET markdown table; paste into Linear BYT-9239 as the diagnosis.
+
+### Out of scope (for this step)
+- Changing Bytebase driver code
+- Upgrading/modifying the forked Go SDK
+- Adding integration tests to the backend

--- a/sdk/data/azcosmos/queryengine/internal/gonative/doc.go
+++ b/sdk/data/azcosmos/queryengine/internal/gonative/doc.go
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package gonative implements queryengine.QueryEngine entirely in Go
+// (no cgo, no native plugins, no external toolchain).
+//
+// It is the default query engine that the azcosmos SDK will auto-wire into
+// cross-partition queries starting at Stage 1 of the BYT-9239 roll-out.
+// In Stage 0 (this package's first release) the engine is inert:
+// SupportedFeatures() returns "" and CreateQueryPipeline returns
+// queryengine.ErrUnsupportedPlanFeature unconditionally.
+package gonative

--- a/sdk/data/azcosmos/queryengine/internal/gonative/engine.go
+++ b/sdk/data/azcosmos/queryengine/internal/gonative/engine.go
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package gonative
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+)
+
+// Engine is the pure-Go implementation of queryengine.QueryEngine.
+// It is constructed by Default(); callers should not instantiate Engine
+// directly because future stages may add required initialization.
+type Engine struct {
+	// (future stages add fields: supportedFeatures set, cardinality caps, etc.)
+}
+
+// Compile-time check that *Engine satisfies the interface.
+var _ queryengine.QueryEngine = (*Engine)(nil)
+
+// Default returns a new Engine with Stage-0 capabilities (none).
+// Callers should treat the returned value as opaque.
+func Default() *Engine {
+	return &Engine{}
+}
+
+// SupportedFeatures implements queryengine.QueryEngine.
+func (e *Engine) SupportedFeatures() string {
+	// Stage 0: advertise no features. Stage 1 appends "Aggregate", etc.
+	return ""
+}
+
+// CreateQueryPipeline implements queryengine.QueryEngine.
+func (e *Engine) CreateQueryPipeline(_ string, _ string, _ string) (queryengine.QueryPipeline, error) {
+	// Stage 0: every query plan is unsupported.
+	return nil, queryengine.ErrUnsupportedPlanFeature
+}
+
+// CreateReadManyPipeline implements queryengine.QueryEngine.
+func (e *Engine) CreateReadManyPipeline(_ []queryengine.ItemIdentity, _ string, _ string, _ uint8, _ []string) (queryengine.QueryPipeline, error) {
+	return nil, queryengine.ErrUnsupportedPlanFeature
+}

--- a/sdk/data/azcosmos/queryengine/internal/gonative/engine_test.go
+++ b/sdk/data/azcosmos/queryengine/internal/gonative/engine_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package gonative_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine/internal/gonative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultReturnsNonNilEngine(t *testing.T) {
+	e := gonative.Default()
+	require.NotNil(t, e)
+}
+
+func TestDefaultAdvertisesNoFeaturesAtStage0(t *testing.T) {
+	assert.Equal(t, "", gonative.Default().SupportedFeatures())
+}
+
+func TestDefaultCreateQueryPipelineReturnsUnsupportedAtStage0(t *testing.T) {
+	_, err := gonative.Default().CreateQueryPipeline("SELECT * FROM c", "{}", "{}")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, queryengine.ErrUnsupportedPlanFeature),
+		"Default() should reject all queries at Stage 0; got %v", err)
+}
+
+func TestDefaultCreateReadManyPipelineReturnsUnsupported(t *testing.T) {
+	_, err := gonative.Default().CreateReadManyPipeline(nil, "{}", "", 0, nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, queryengine.ErrUnsupportedPlanFeature))
+}
+
+func TestDefaultReturnsDistinctEngineInstances(t *testing.T) {
+	// Each caller gets its own instance — enables per-engine caches in later stages.
+	a := gonative.Default()
+	b := gonative.Default()
+	assert.NotSame(t, a, b)
+}


### PR DESCRIPTION
Part 1 of 7 for [BYT-9239](https://linear.app/bytebase/issue/BYT-9239). This PR adds the infrastructure for the pure-Go distributed query engine that later stages will populate with real operators. **No behavior change** — the engine is inert and is not yet auto-enabled.

## What lands

- `queryengine.Disabled` sentinel + `queryengine.ErrUnsupportedPlanFeature` error.
- `queryengine/internal/gonative` sub-package with `Default()` returning an `*Engine` that advertises no features and rejects every `CreateQueryPipeline` call with `ErrUnsupportedPlanFeature`.
- `ClientOptions.QueryPlanCacheSize` (0 = default 256, <0 = disabled).
- Per-container LRU plan cache on `ContainerClient` (allocated at construction; unused until Stage 1).
- `github.com/hashicorp/golang-lru/v2 v2.0.7` dep.

## Why internal/

The `gonative` package lives under `internal/` so its surface can be refactored freely across Stages 1-6. Only the `queryengine.QueryEngine` interface implementation escapes. Nothing in the public `azcosmos` API changes.

## Test plan
- [x] `go build ./sdk/data/azcosmos/...` clean
- [x] `go test -race ./sdk/data/azcosmos/... -count=1 -timeout 180s` PASS
- [x] `go vet ./sdk/data/azcosmos/...` clean
- [x] Stage 0 is a no-op at runtime: queries currently succeeding continue to succeed; queries currently failing continue to fail with the same gateway error.
- [ ] Reviewer: sanity-check the CHANGELOG wording and confirm no public API signature changed.

See `docs/superpowers/specs/2026-04-22-cosmos-cross-partition-query-engine-design.md` in the Bytebase repo for the full design — this PR implements Section 4 Stage 0.