### PR TITLE
azcosmos: Stage 3 — single-key ORDER BY (BYT-9239)

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added `queryengine/gonative` sub-package that implements `queryengine.QueryEngine` with the aggregate operators listed above.
 * Added `ClientOptions.QueryPlanCacheSize` and a per-container LRU plan cache. The cache is consulted around `getQueryPlanFromGateway` in the engine path so repeated queries within a session skip the plan round-trip.
 * Added Stage 2 of the pure-Go query engine: `DISTINCT` and `DISTINCT VALUE` support via a streaming hash-set keyed on canonical JSON. `SELECT DISTINCT c.field FROM c` and `SELECT DISTINCT VALUE c.field FROM c` now succeed cross-partition. The seen-set grows unbounded — same behavior as the .NET SDK's [`UnorderedDistinctMap`](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctMap.UnorderedDistinctMap.cs). See [BYT-9239](https://linear.app/bytebase/issue/BYT-9239).
+* Added Stage 3 of the pure-Go query engine: single-key `ORDER BY` (ASC and DESC). `SELECT ... FROM c ORDER BY c.field [ASC|DESC]` now succeeds cross-partition through a k-way merge across gateway-sorted partition streams. The comparator honors Cosmos item ordering (`undefined < null < bool < number < string`). Multi-key `ORDER BY` and continuation tokens are out of scope for this release. See [BYT-9239](https://linear.app/bytebase/issue/BYT-9239).
 
 ### Breaking Changes
 

--- a/sdk/data/azcosmos/queryengine/gonative/engine.go
+++ b/sdk/data/azcosmos/queryengine/gonative/engine.go
@@ -32,7 +32,8 @@ func Default() *Engine {
 //	MultipleAggregates     — multi-aggregate in a single SELECT (Stage 1)
 //	DistinctValue          — SELECT DISTINCT VALUE c.field FROM c (Stage 2)
 //	Distinct               — SELECT DISTINCT c.field FROM c — object form (Stage 2)
-const supportedFeatures = "Aggregate,NonValueAggregate,MultipleAggregates,Distinct,DistinctValue"
+//	OrderBy                — single-key ORDER BY (Stage 3)
+const supportedFeatures = "Aggregate,NonValueAggregate,MultipleAggregates,Distinct,DistinctValue,OrderBy"
 
 // SupportedFeatures implements queryengine.QueryEngine.
 func (e *Engine) SupportedFeatures() string {
@@ -55,6 +56,8 @@ func (e *Engine) CreateQueryPipeline(query string, plan string, pkranges string)
 		return nil, err
 	}
 	switch {
+	case len(p.QueryInfo.OrderBy) > 0:
+		return newOrderByPipeline(p, rangeIDs)
 	case p.QueryInfo.DistinctType == "Unordered":
 		pipe, err := newDistinctPipeline(p, rangeIDs)
 		if err != nil {
@@ -84,14 +87,16 @@ func (e *Engine) CreateQueryPipeline(query string, plan string, pkranges string)
 // entries from this guard as their operators come online.
 func rejectUnsupportedPlan(p *planDoc) error {
 	qi := p.QueryInfo
-	// "Ordered" DISTINCT composes with ORDER BY merge (Stage 3); reject for now.
+	// "Ordered" DISTINCT composes with ORDER BY merge; reject until Stage 3
+	// wires composition through the merge heap. Stage 3 itself handles plain
+	// ORDER BY — see the dispatch above.
 	if qi.DistinctType == "Ordered" {
 		return queryengine.ErrUnsupportedPlanFeature
 	}
 	if qi.DistinctType != "" && qi.DistinctType != "None" && qi.DistinctType != "Unordered" {
 		return queryengine.ErrUnsupportedPlanFeature
 	}
-	if len(qi.OrderBy) > 0 || len(qi.GroupByExpressions) > 0 {
+	if len(qi.GroupByExpressions) > 0 {
 		return queryengine.ErrUnsupportedPlanFeature
 	}
 	if qi.Top != nil || qi.Offset != nil || qi.Limit != nil {

--- a/sdk/data/azcosmos/queryengine/gonative/engine_test.go
+++ b/sdk/data/azcosmos/queryengine/gonative/engine_test.go
@@ -33,8 +33,9 @@ func TestDefaultCreateQueryPipelineRejectsUnparseablePlan(t *testing.T) {
 }
 
 func TestDefaultCreateQueryPipelineRejectsUnsupportedPlan(t *testing.T) {
-	// A plan carrying an ORDER BY instruction is out of Stage 1 scope.
-	plan := `{"partitionedQueryExecutionInfoVersion":2,"queryInfo":{"orderBy":["Ascending"],"orderByExpressions":["c.x"]}}`
+	// A plan carrying a GROUP BY instruction is out of the engine's current
+	// scope — GROUP BY lands in Stage 6. This guard exercises the reject path.
+	plan := `{"partitionedQueryExecutionInfoVersion":2,"queryInfo":{"groupByExpressions":["c.country"]}}`
 	pkranges := `{"PartitionKeyRanges":[{"id":"0"}]}`
 	_, err := gonative.Default().CreateQueryPipeline("SELECT ...", plan, pkranges)
 	require.Error(t, err)

--- a/sdk/data/azcosmos/queryengine/gonative/integration_stage3_test.go
+++ b/sdk/data/azcosmos/queryengine/gonative/integration_stage3_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package gonative_test
+
+// Stage 3 live-Azure integration tests for BYT-9239. Guarded by AZURE_COSMOS_KEY.
+//
+//   export AZURE_COSMOS_ENDPOINT="https://...documents.azure.com:443/"
+//   export AZURE_COSMOS_KEY="$(az cosmosdb keys list --name ... -o tsv)"
+//   go test -count=1 -run "^TestIntegration_BYT9239_Stage3" \
+//       ./sdk/data/azcosmos/queryengine/gonative/
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newContainerS3(t *testing.T) *azcosmos.ContainerClient {
+	t.Helper()
+	endpoint, key, dbName, collName := skipIfNoAzureStage2(t) // same env guard as Stage 2
+	cred, err := azcosmos.NewKeyCredential(key)
+	require.NoError(t, err)
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	require.NoError(t, err)
+	container, err := client.NewContainer(dbName, collName)
+	require.NoError(t, err)
+	return container
+}
+
+// sortKey extracts a comparable representation of a row's `population` field
+// that honors Cosmos item ordering: numbers sort before strings, so we tag
+// the value with the type class first. Returned tuple is (typeRank, raw).
+func sortKey(t *testing.T, row []byte) (int, any) {
+	t.Helper()
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(row, &obj))
+	v, ok := obj["population"]
+	require.True(t, ok, "row missing population: %s", row)
+	switch x := v.(type) {
+	case float64:
+		return 3, x // numbers
+	case string:
+		return 4, x // strings
+	case bool:
+		return 2, x
+	case nil:
+		return 1, x
+	default:
+		return 0, x
+	}
+}
+
+func TestIntegration_BYT9239_Stage3_4_1_Ascending(t *testing.T) {
+	container := newContainerS3(t)
+	rows := drainAzure(t, container, `SELECT c.name, c.population FROM c ORDER BY c.population ASC`)
+	require.NotEmpty(t, rows, "expected rows back")
+
+	// Verify the result is in ascending order under Cosmos item ordering.
+	var prevRank int
+	var prevVal any
+	for i, r := range rows {
+		rank, val := sortKey(t, r)
+		if i == 0 {
+			prevRank, prevVal = rank, val
+			continue
+		}
+		if rank != prevRank {
+			assert.GreaterOrEqual(t, rank, prevRank, "type-rank must not regress at row %d: %s", i, r)
+			prevRank, prevVal = rank, val
+			continue
+		}
+		switch pv := prevVal.(type) {
+		case float64:
+			assert.LessOrEqual(t, pv, val.(float64), "ascending number order broken at row %d", i)
+		case string:
+			assert.LessOrEqual(t, pv, val.(string), "ascending string order broken at row %d", i)
+		}
+		prevVal = val
+	}
+	t.Logf("ASC verified across %d rows", len(rows))
+}
+
+func TestIntegration_BYT9239_Stage3_4_2_Descending(t *testing.T) {
+	container := newContainerS3(t)
+	rows := drainAzure(t, container, `SELECT c.name, c.population FROM c ORDER BY c.population DESC`)
+	require.NotEmpty(t, rows)
+
+	var prevRank int
+	var prevVal any
+	for i, r := range rows {
+		rank, val := sortKey(t, r)
+		if i == 0 {
+			prevRank, prevVal = rank, val
+			continue
+		}
+		if rank != prevRank {
+			assert.LessOrEqual(t, rank, prevRank, "type-rank must not ascend under DESC at row %d: %s", i, r)
+			prevRank, prevVal = rank, val
+			continue
+		}
+		switch pv := prevVal.(type) {
+		case float64:
+			assert.GreaterOrEqual(t, pv, val.(float64), "descending number order broken at row %d", i)
+		case string:
+			assert.GreaterOrEqual(t, pv, val.(string), "descending string order broken at row %d", i)
+		}
+		prevVal = val
+	}
+	t.Logf("DESC verified across %d rows", len(rows))
+}

--- a/sdk/data/azcosmos/queryengine/gonative/merge.go
+++ b/sdk/data/azcosmos/queryengine/gonative/merge.go
@@ -1,0 +1,295 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package gonative
+
+import (
+	"container/heap"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+)
+
+// orderByQueryFilterPlaceholder is the token the gateway embeds into ORDER BY
+// rewritten queries. The client-side engine must substitute it before firing
+// per-partition requests — with "true" on the initial page, and with a
+// continuation filter comparing the last emitted order-by key on subsequent
+// pages. Stage 3 handles the single-page case only; continuation is deferred.
+const orderByQueryFilterPlaceholder = "{documentdb-formattableorderbyquery-filter}"
+
+// orderByItem is each element of the per-document orderByItems array. The
+// gateway emits one per ORDER BY expression; Stage 3 only supports single-key
+// ORDER BY so we read orderByItems[0].
+type orderByItem struct {
+	Item json.RawMessage `json:"item"`
+}
+
+// orderByDoc is one Documents[i] entry in an ORDER BY partition response.
+// Payload is the user's projected row — what we eventually emit.
+type orderByDoc struct {
+	OrderByItems []orderByItem   `json:"orderByItems"`
+	Payload      json.RawMessage `json:"payload"`
+}
+
+// orderByPartitionResponse decodes an ORDER BY per-partition response body.
+type orderByPartitionResponse struct {
+	Documents []orderByDoc `json:"Documents"`
+}
+
+func parseOrderByPartitionResponse(raw []byte) (*orderByPartitionResponse, error) {
+	var r orderByPartitionResponse
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("gonative: parse order-by partition response: %w", err)
+	}
+	return &r, nil
+}
+
+// partitionStream holds one partition's ORDER BY documents, in gateway-sorted
+// order. The pipeline pops from the head as the heap selects from this
+// partition; emptying the slice means the partition is drained.
+type partitionStream struct {
+	docs []orderByDoc
+	head int // index of next doc to emit; len(docs)-head is the remaining count
+}
+
+func (s *partitionStream) peek() (*orderByDoc, bool) {
+	if s.head >= len(s.docs) {
+		return nil, false
+	}
+	return &s.docs[s.head], true
+}
+
+func (s *partitionStream) pop() *orderByDoc {
+	d := &s.docs[s.head]
+	s.head++
+	return d
+}
+
+// mergeHeap implements heap.Interface over partition indices. The comparator
+// uses compareItems on each partition's current head's orderByItems[0], with
+// the sort direction flipped for descending ORDER BY.
+type mergeHeap struct {
+	partitions []*partitionStream
+	idx        []int  // heap of partition indices
+	descending bool
+}
+
+func (h *mergeHeap) Len() int { return len(h.idx) }
+
+func (h *mergeHeap) Less(i, j int) bool {
+	// We never call Less when a partition is empty — the pipeline drops empty
+	// partitions from the heap before they can be compared.
+	a, _ := h.partitions[h.idx[i]].peek()
+	b, _ := h.partitions[h.idx[j]].peek()
+	cmp, err := compareItems(a.OrderByItems[0].Item, b.OrderByItems[0].Item)
+	if err != nil {
+		// compareItems rejects unorderable shapes (arrays, objects). For
+		// ORDER BY scalars this should never happen; if it does, fall back to
+		// stable-by-partition-index order so the heap remains well-defined.
+		return h.idx[i] < h.idx[j]
+	}
+	if h.descending {
+		return cmp > 0
+	}
+	return cmp < 0
+}
+
+func (h *mergeHeap) Swap(i, j int) { h.idx[i], h.idx[j] = h.idx[j], h.idx[i] }
+
+func (h *mergeHeap) Push(x any) { h.idx = append(h.idx, x.(int)) }
+
+func (h *mergeHeap) Pop() any {
+	n := len(h.idx)
+	out := h.idx[n-1]
+	h.idx = h.idx[:n-1]
+	return out
+}
+
+// orderByPipeline implements queryengine.QueryPipeline for plans with a single
+// ORDER BY expression. It emits rows in the requested order by k-way-merging
+// each partition's gateway-sorted stream.
+//
+// Stage 3 scope is single-key ORDER BY only. Multi-key ORDER BY requires a
+// Cosmos composite index on the container — if the container lacks one the
+// gateway rejects the query outright; if it has one the gateway emits a plan
+// with multiple entries in orderByExpressions, and the comparator would need
+// to walk all of them. Both cases are deferred.
+type orderByPipeline struct {
+	rewrittenQuery string
+	pkRangeIDs     []string
+	descending     bool
+
+	partitionsDone map[string]bool
+	partitionByID  map[string]int
+	partitions     []*partitionStream
+
+	heap   *mergeHeap
+	issued bool
+	closed bool
+
+	// pending emits produced by k-way merging when all partitions have data.
+	pending [][]byte
+}
+
+// newOrderByPipeline constructs a pipeline for a plan with exactly one ORDER BY
+// expression. Returns ErrUnsupportedPlanFeature when the plan names multiple
+// ORDER BY keys — Stage 3 doesn't yet support that composition.
+func newOrderByPipeline(plan *planDoc, pkRangeIDs []string) (*orderByPipeline, error) {
+	if len(plan.QueryInfo.OrderBy) != 1 {
+		return nil, queryengine.ErrUnsupportedPlanFeature
+	}
+	if plan.QueryInfo.OrderBy[0] != "Ascending" && plan.QueryInfo.OrderBy[0] != "Descending" {
+		return nil, queryengine.ErrUnsupportedPlanFeature
+	}
+	// Substitute the formattable-order-by-query-filter placeholder with "true"
+	// for the initial request per partition. Multi-page continuation (which
+	// would substitute with a tail-comparison filter) is out of Stage 3's scope.
+	query := strings.ReplaceAll(plan.QueryInfo.RewrittenQuery, orderByQueryFilterPlaceholder, "true")
+
+	partByID := make(map[string]int, len(pkRangeIDs))
+	partitions := make([]*partitionStream, len(pkRangeIDs))
+	for i, id := range pkRangeIDs {
+		partByID[id] = i
+		partitions[i] = &partitionStream{}
+	}
+	return &orderByPipeline{
+		rewrittenQuery: query,
+		pkRangeIDs:     append([]string(nil), pkRangeIDs...),
+		descending:     plan.QueryInfo.OrderBy[0] == "Descending",
+		partitionsDone: make(map[string]bool, len(pkRangeIDs)),
+		partitionByID:  partByID,
+		partitions:     partitions,
+	}, nil
+}
+
+func (p *orderByPipeline) Query() string  { return p.rewrittenQuery }
+func (p *orderByPipeline) Close()         { p.closed = true }
+
+// IsComplete returns true once every partition's gateway response has been
+// merged and the last pending row has been handed to the caller.
+func (p *orderByPipeline) IsComplete() bool {
+	if !p.issued {
+		return false
+	}
+	if len(p.pending) > 0 {
+		return false
+	}
+	for _, id := range p.pkRangeIDs {
+		if !p.partitionsDone[id] {
+			return false
+		}
+	}
+	// All partitions have delivered data; anything still in the heap or in a
+	// partition buffer needs to flush before we can call it done.
+	if p.heap != nil && p.heap.Len() > 0 {
+		return false
+	}
+	for _, s := range p.partitions {
+		if s.head < len(s.docs) {
+			return false
+		}
+	}
+	return true
+}
+
+// Run drives one pipeline turn.
+//  1. First call: fan out one request per pk-range carrying the (substituted)
+//     rewritten query.
+//  2. After every partition has provided data, drain the heap into `pending`,
+//     then emit.
+func (p *orderByPipeline) Run() (*queryengine.PipelineResult, error) {
+	if !p.issued {
+		reqs := make([]queryengine.QueryRequest, len(p.pkRangeIDs))
+		for i, id := range p.pkRangeIDs {
+			reqs[i] = queryengine.QueryRequest{
+				PartitionKeyRangeID: id,
+				Id:                  uint64(i),
+				Query:               p.rewrittenQuery,
+				IncludeParameters:   true,
+			}
+		}
+		p.issued = true
+		return &queryengine.PipelineResult{Requests: reqs}, nil
+	}
+
+	if p.heap == nil && p.allPartitionsReady() {
+		p.initHeap()
+		p.drain()
+	}
+
+	if len(p.pending) > 0 {
+		batch := p.pending
+		p.pending = nil
+		return &queryengine.PipelineResult{Items: batch, IsCompleted: p.IsComplete()}, nil
+	}
+	return &queryengine.PipelineResult{IsCompleted: p.IsComplete()}, nil
+}
+
+// ProvideData parses and stores each partition's response. Validates that
+// every document has at least one orderByItems entry and a payload.
+func (p *orderByPipeline) ProvideData(results []queryengine.QueryResult) error {
+	for _, r := range results {
+		resp, err := parseOrderByPartitionResponse(r.Data)
+		if err != nil {
+			return err
+		}
+		for i, doc := range resp.Documents {
+			if len(doc.OrderByItems) == 0 {
+				return fmt.Errorf("gonative: order-by doc %d missing orderByItems", i)
+			}
+			if len(doc.Payload) == 0 {
+				return fmt.Errorf("gonative: order-by doc %d missing payload", i)
+			}
+		}
+		if r.NextContinuation != "" {
+			return fmt.Errorf("gonative: order-by partition returned a continuation token (multi-page not supported in Stage 3)")
+		}
+		idx, ok := p.partitionByID[r.PartitionKeyRangeID]
+		if !ok {
+			return fmt.Errorf("gonative: unexpected partition id %q", r.PartitionKeyRangeID)
+		}
+		p.partitions[idx].docs = append(p.partitions[idx].docs, resp.Documents...)
+		p.partitionsDone[r.PartitionKeyRangeID] = true
+	}
+	return nil
+}
+
+func (p *orderByPipeline) allPartitionsReady() bool {
+	for _, id := range p.pkRangeIDs {
+		if !p.partitionsDone[id] {
+			return false
+		}
+	}
+	return true
+}
+
+// initHeap seeds the merge heap with every non-empty partition's head.
+func (p *orderByPipeline) initHeap() {
+	h := &mergeHeap{partitions: p.partitions, descending: p.descending}
+	for i, s := range p.partitions {
+		if _, ok := s.peek(); ok {
+			h.idx = append(h.idx, i)
+		}
+	}
+	heap.Init(h)
+	p.heap = h
+}
+
+// drain flushes the k-way merge into p.pending. After Stage 3's single-page
+// guarantee the heap holds at most one row per partition; popping the top,
+// advancing that partition, and re-pushing (if not drained) emits the
+// globally-next row. Runs to completion in one Run() turn.
+func (p *orderByPipeline) drain() {
+	for p.heap.Len() > 0 {
+		top := heap.Pop(p.heap).(int)
+		s := p.partitions[top]
+		doc := s.pop()
+		// Defensive copy — json.RawMessage aliases the underlying buffer.
+		p.pending = append(p.pending, append([]byte(nil), doc.Payload...))
+		if _, ok := s.peek(); ok {
+			heap.Push(p.heap, top)
+		}
+	}
+}

--- a/sdk/data/azcosmos/queryengine/gonative/merge_test.go
+++ b/sdk/data/azcosmos/queryengine/gonative/merge_test.go
@@ -1,0 +1,277 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package gonative
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mkOrderByBody constructs a partition response body carrying an arbitrary
+// sequence of (orderByValue, payload) pairs. The sequence is NOT sorted here —
+// callers pass a pre-sorted list because the gateway would have sorted within
+// the partition.
+func mkOrderByBody(t *testing.T, entries ...struct {
+	ob, payload string
+}) []byte {
+	t.Helper()
+	docs := make([]orderByDoc, 0, len(entries))
+	for _, e := range entries {
+		docs = append(docs, orderByDoc{
+			OrderByItems: []orderByItem{{Item: json.RawMessage(e.ob)}},
+			Payload:      json.RawMessage(e.payload),
+		})
+	}
+	body, err := json.Marshal(struct {
+		Documents []orderByDoc `json:"Documents"`
+	}{docs})
+	require.NoError(t, err)
+	return body
+}
+
+// ordered is a shorthand for the (orderByItems[0].item, payload) tuple used
+// in fixture construction.
+type ordered = struct {
+	ob, payload string
+}
+
+func newAscPipeline(t *testing.T, pkRangeIDs ...string) *orderByPipeline {
+	t.Helper()
+	plan := &planDoc{}
+	plan.QueryInfo.OrderBy = []string{"Ascending"}
+	plan.QueryInfo.RewrittenQuery = `SELECT c._rid, [{"item":c.x}] AS orderByItems, c AS payload FROM c WHERE ({documentdb-formattableorderbyquery-filter}) ORDER BY c.x ASC`
+	p, err := newOrderByPipeline(plan, pkRangeIDs)
+	require.NoError(t, err)
+	return p
+}
+
+func newDescPipeline(t *testing.T, pkRangeIDs ...string) *orderByPipeline {
+	t.Helper()
+	plan := &planDoc{}
+	plan.QueryInfo.OrderBy = []string{"Descending"}
+	plan.QueryInfo.RewrittenQuery = `SELECT c._rid, [{"item":c.x}] AS orderByItems, c AS payload FROM c WHERE ({documentdb-formattableorderbyquery-filter}) ORDER BY c.x DESC`
+	p, err := newOrderByPipeline(plan, pkRangeIDs)
+	require.NoError(t, err)
+	return p
+}
+
+// runOnePass drives the pipeline through: initial Run() → feed → flush.
+// Returns every emitted row as a JSON string.
+func runOnePass(t *testing.T, p *orderByPipeline, feed map[string][]byte) []string {
+	t.Helper()
+	res, err := p.Run()
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Requests, "expected initial fan-out")
+
+	results := make([]queryengine.QueryResult, 0, len(res.Requests))
+	for _, req := range res.Requests {
+		body, ok := feed[req.PartitionKeyRangeID]
+		require.True(t, ok, "missing fixture for %s", req.PartitionKeyRangeID)
+		results = append(results, queryengine.NewQueryResult(req.PartitionKeyRangeID, body, ""))
+	}
+	require.NoError(t, p.ProvideData(results))
+
+	var out []string
+	for !p.IsComplete() {
+		r, err := p.Run()
+		require.NoError(t, err)
+		for _, it := range r.Items {
+			out = append(out, string(it))
+		}
+	}
+	return out
+}
+
+// --------------------------------------------------------------- placeholder
+
+func TestNewOrderByPipeline_SubstitutesFilterPlaceholder(t *testing.T) {
+	p := newAscPipeline(t, "0")
+	assert.NotContains(t, p.Query(), orderByQueryFilterPlaceholder)
+	assert.Contains(t, p.Query(), "WHERE (true)",
+		"initial per-partition request must substitute the placeholder with true")
+}
+
+// ----------------------------------------------------------- single-partition
+
+func TestOrderByPipeline_SinglePartition_Ascending(t *testing.T) {
+	p := newAscPipeline(t, "0")
+	rows := runOnePass(t, p, map[string][]byte{
+		"0": mkOrderByBody(t,
+			ordered{ob: `1`, payload: `{"x":1}`},
+			ordered{ob: `5`, payload: `{"x":5}`},
+			ordered{ob: `9`, payload: `{"x":9}`},
+		),
+	})
+	assert.Equal(t, []string{`{"x":1}`, `{"x":5}`, `{"x":9}`}, rows)
+}
+
+func TestOrderByPipeline_SinglePartition_Descending(t *testing.T) {
+	p := newDescPipeline(t, "0")
+	rows := runOnePass(t, p, map[string][]byte{
+		"0": mkOrderByBody(t,
+			ordered{ob: `9`, payload: `{"x":9}`},
+			ordered{ob: `5`, payload: `{"x":5}`},
+			ordered{ob: `1`, payload: `{"x":1}`},
+		),
+	})
+	assert.Equal(t, []string{`{"x":9}`, `{"x":5}`, `{"x":1}`}, rows)
+}
+
+// ----------------------------------------------------------- multi-partition
+
+func TestOrderByPipeline_MultiPartitionKWayMerge_Ascending(t *testing.T) {
+	// Three pre-sorted streams; expect interleaved global order.
+	p := newAscPipeline(t, "A", "B", "C")
+	rows := runOnePass(t, p, map[string][]byte{
+		"A": mkOrderByBody(t,
+			ordered{ob: `1`, payload: `{"id":"a1"}`},
+			ordered{ob: `4`, payload: `{"id":"a4"}`},
+			ordered{ob: `7`, payload: `{"id":"a7"}`},
+		),
+		"B": mkOrderByBody(t,
+			ordered{ob: `2`, payload: `{"id":"b2"}`},
+			ordered{ob: `5`, payload: `{"id":"b5"}`},
+			ordered{ob: `8`, payload: `{"id":"b8"}`},
+		),
+		"C": mkOrderByBody(t,
+			ordered{ob: `3`, payload: `{"id":"c3"}`},
+			ordered{ob: `6`, payload: `{"id":"c6"}`},
+			ordered{ob: `9`, payload: `{"id":"c9"}`},
+		),
+	})
+	assert.Equal(t, []string{
+		`{"id":"a1"}`, `{"id":"b2"}`, `{"id":"c3"}`,
+		`{"id":"a4"}`, `{"id":"b5"}`, `{"id":"c6"}`,
+		`{"id":"a7"}`, `{"id":"b8"}`, `{"id":"c9"}`,
+	}, rows)
+}
+
+func TestOrderByPipeline_MultiPartitionKWayMerge_Descending(t *testing.T) {
+	p := newDescPipeline(t, "A", "B")
+	rows := runOnePass(t, p, map[string][]byte{
+		"A": mkOrderByBody(t,
+			ordered{ob: `9`, payload: `{"id":"a9"}`},
+			ordered{ob: `5`, payload: `{"id":"a5"}`},
+			ordered{ob: `1`, payload: `{"id":"a1"}`},
+		),
+		"B": mkOrderByBody(t,
+			ordered{ob: `10`, payload: `{"id":"b10"}`},
+			ordered{ob: `7`, payload: `{"id":"b7"}`},
+			ordered{ob: `3`, payload: `{"id":"b3"}`},
+		),
+	})
+	assert.Equal(t, []string{
+		`{"id":"b10"}`, `{"id":"a9"}`, `{"id":"b7"}`, `{"id":"a5"}`, `{"id":"b3"}`, `{"id":"a1"}`,
+	}, rows)
+}
+
+// --------------------------------------- type-aware ordering (Cosmos rules)
+
+func TestOrderByPipeline_MixedTypes_Ascending(t *testing.T) {
+	// Cosmos order: undefined < null < bool < number < string.
+	// One partition emits numbers, another emits strings. ASC => numbers first.
+	p := newAscPipeline(t, "nums", "strs")
+	rows := runOnePass(t, p, map[string][]byte{
+		"nums": mkOrderByBody(t,
+			ordered{ob: `3`, payload: `{"kind":"num","v":3}`},
+			ordered{ob: `7`, payload: `{"kind":"num","v":7}`},
+		),
+		"strs": mkOrderByBody(t,
+			ordered{ob: `"AD"`, payload: `{"kind":"str","v":"AD"}`},
+			ordered{ob: `"AE"`, payload: `{"kind":"str","v":"AE"}`},
+		),
+	})
+	assert.Equal(t, []string{
+		`{"kind":"num","v":3}`,
+		`{"kind":"num","v":7}`,
+		`{"kind":"str","v":"AD"}`,
+		`{"kind":"str","v":"AE"}`,
+	}, rows)
+}
+
+func TestOrderByPipeline_MixedTypes_Descending(t *testing.T) {
+	p := newDescPipeline(t, "nums", "strs")
+	rows := runOnePass(t, p, map[string][]byte{
+		"nums": mkOrderByBody(t,
+			ordered{ob: `7`, payload: `{"v":7}`},
+			ordered{ob: `3`, payload: `{"v":3}`},
+		),
+		"strs": mkOrderByBody(t,
+			ordered{ob: `"AE"`, payload: `{"v":"AE"}`},
+			ordered{ob: `"AD"`, payload: `{"v":"AD"}`},
+		),
+	})
+	// DESC: strings first (largest), then numbers.
+	assert.Equal(t, []string{
+		`{"v":"AE"}`, `{"v":"AD"}`, `{"v":7}`, `{"v":3}`,
+	}, rows)
+}
+
+// --------------------------------------- empty and malformed partitions
+
+func TestOrderByPipeline_EmptyPartition(t *testing.T) {
+	p := newAscPipeline(t, "A", "B")
+	rows := runOnePass(t, p, map[string][]byte{
+		"A": mkOrderByBody(t), // empty
+		"B": mkOrderByBody(t, ordered{ob: `5`, payload: `{"x":5}`}),
+	})
+	assert.Equal(t, []string{`{"x":5}`}, rows)
+	assert.True(t, p.IsComplete())
+}
+
+func TestOrderByPipeline_AllPartitionsEmpty(t *testing.T) {
+	p := newAscPipeline(t, "A", "B")
+	rows := runOnePass(t, p, map[string][]byte{
+		"A": mkOrderByBody(t),
+		"B": mkOrderByBody(t),
+	})
+	assert.Empty(t, rows)
+	assert.True(t, p.IsComplete())
+}
+
+func TestOrderByPipeline_RejectsMultiKeyPlan(t *testing.T) {
+	plan := &planDoc{}
+	plan.QueryInfo.OrderBy = []string{"Ascending", "Descending"}
+	plan.QueryInfo.RewrittenQuery = "SELECT ... ORDER BY c.a, c.b"
+	_, err := newOrderByPipeline(plan, []string{"0"})
+	require.ErrorIs(t, err, queryengine.ErrUnsupportedPlanFeature)
+}
+
+func TestOrderByPipeline_RejectsMissingPayload(t *testing.T) {
+	p := newAscPipeline(t, "0")
+	_, _ = p.Run()
+	// Document with orderByItems but no payload.
+	body := []byte(`{"Documents":[{"orderByItems":[{"item":1}]}]}`)
+	err := p.ProvideData([]queryengine.QueryResult{
+		{PartitionKeyRangeID: "0", Data: body},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing payload")
+}
+
+func TestOrderByPipeline_RejectsMissingOrderByItems(t *testing.T) {
+	p := newAscPipeline(t, "0")
+	_, _ = p.Run()
+	body := []byte(`{"Documents":[{"payload":{"x":1}}]}`)
+	err := p.ProvideData([]queryengine.QueryResult{
+		{PartitionKeyRangeID: "0", Data: body},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing orderByItems")
+}
+
+func TestOrderByPipeline_RejectsContinuationToken(t *testing.T) {
+	p := newAscPipeline(t, "0")
+	_, _ = p.Run()
+	body := mkOrderByBody(t, ordered{ob: `1`, payload: `{}`})
+	err := p.ProvideData([]queryengine.QueryResult{
+		{PartitionKeyRangeID: "0", Data: body, NextContinuation: "cont"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "continuation token")
+}

--- a/sdk/data/azcosmos/queryengine/gonative/pipeline_test.go
+++ b/sdk/data/azcosmos/queryengine/gonative/pipeline_test.go
@@ -203,6 +203,29 @@ func TestDistinctPipeline_10_1_ObjectDistinct(t *testing.T) {
 	}
 }
 
+func TestOrderByPipeline_4_1_Ascending(t *testing.T) {
+	rows := drivePipelineAll(t, "4_1", `SELECT c.name, c.population FROM c ORDER BY c.population ASC`)
+	// Captured fixture: 18 cities in the WorldCities test container, mixed
+	// numeric + string populations (the gateway delivered them pre-sorted).
+	assert.Len(t, rows, 18, "expected one row per city")
+	// First row should be the smallest population (number type comes before
+	// string under Cosmos ordering, so this is a numeric).
+	var first map[string]any
+	require.NoError(t, json.Unmarshal(rows[0], &first))
+	_, ok := first["population"].(float64)
+	assert.True(t, ok, "first row under ASC ordering must be numeric population (numbers sort before strings)")
+}
+
+func TestOrderByPipeline_4_2_Descending(t *testing.T) {
+	rows := drivePipelineAll(t, "4_2", `SELECT c.name, c.population FROM c ORDER BY c.population DESC`)
+	assert.Len(t, rows, 18)
+	// DESC: strings come first (strings > numbers under Cosmos ordering).
+	var first map[string]any
+	require.NoError(t, json.Unmarshal(rows[0], &first))
+	_, ok := first["population"].(string)
+	assert.True(t, ok, "first row under DESC must be a string-valued population (strings sort after numbers)")
+}
+
 func TestDistinctPipeline_10_2_DistinctValue(t *testing.T) {
 	rows := drivePipelineAll(t, "10_2", `SELECT DISTINCT VALUE c.countryRegion FROM c`)
 	// Captured fixture has 6 unique countryRegion scalars.

--- a/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_1_partitions/range_0.json
+++ b/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_1_partitions/range_0.json
@@ -1,0 +1,222 @@
+{
+    "_rid": "S9w7AIGecFs=",
+    "Documents": [
+        {
+            "_rid": "S9w7AIGecFsEAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 15000
+                }
+            ],
+            "payload": {
+                "name": "Ar Ruways",
+                "population": 15000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsGAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 22256
+                }
+            ],
+            "payload": {
+                "name": "Andorra la Vella",
+                "population": 22256
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsHAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 62000
+                }
+            ],
+            "payload": {
+                "name": "Umm Al Qaywayn",
+                "population": 62000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsMAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 553230
+                }
+            ],
+            "payload": {
+                "name": "Manchester",
+                "population": 553230
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsFAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 1274749
+                }
+            ],
+            "payload": {
+                "name": "Sharjah",
+                "population": 1274749
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsKAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 2693976
+                }
+            ],
+            "payload": {
+                "name": "Chicago",
+                "population": 2693976
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsOAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 2753000
+                }
+            ],
+            "payload": {
+                "name": "Osaka",
+                "population": 2753000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsDAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 3400800
+                }
+            ],
+            "payload": {
+                "name": "Dubai",
+                "population": 3400800
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsPAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 3645000
+                }
+            ],
+            "payload": {
+                "name": "Berlin",
+                "population": 3645000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsJAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 3979576
+                }
+            ],
+            "payload": {
+                "name": "Los Angeles",
+                "population": 3979576
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsIAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 8336817
+                }
+            ],
+            "payload": {
+                "name": "New York",
+                "population": 8336817
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsLAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 8982000
+                }
+            ],
+            "payload": {
+                "name": "London",
+                "population": 8982000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsNAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 13960000
+                }
+            ],
+            "payload": {
+                "name": "Tokyo",
+                "population": 13960000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsQAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "22256"
+                }
+            ],
+            "payload": {
+                "name": "Andorra la Vella",
+                "population": "22256"
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsCAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "2956587"
+                }
+            ],
+            "payload": {
+                "name": "Dubai",
+                "population": "2956587"
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsBAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "62415"
+                }
+            ],
+            "payload": {
+                "name": "Al Fujayrah",
+                "population": "62415"
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsRAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "8419000"
+                }
+            ],
+            "payload": {
+                "name": "New York",
+                "population": "8419000"
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsSAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "8982000"
+                }
+            ],
+            "payload": {
+                "name": "London",
+                "population": "8982000"
+            }
+        }
+    ],
+    "_count": 18
+}

--- a/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_1_pkranges.json
+++ b/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_1_pkranges.json
@@ -1,0 +1,21 @@
+{
+    "_rid": "S9w7AIGecFs=",
+    "PartitionKeyRanges": [
+        {
+            "_rid": "S9w7AIGecFsCAAAAAAAAUA==",
+            "id": "0",
+            "_etag": "\"0000d642-0000-0100-0000-69de026a0000\"",
+            "minInclusive": "",
+            "maxExclusive": "FF",
+            "ridPrefix": 0,
+            "_self": "dbs/S9w7AA==/colls/S9w7AIGecFs=/pkranges/S9w7AIGecFsCAAAAAAAAUA==/",
+            "throughputFraction": 1,
+            "status": "online",
+            "parents": [],
+            "ownedArchivalPKRangeIds": [],
+            "_ts": 1776157290,
+            "lsn": 15
+        }
+    ],
+    "_count": 1
+}

--- a/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_1_plan.json
+++ b/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_1_plan.json
@@ -1,0 +1,32 @@
+{
+    "partitionedQueryExecutionInfoVersion": 2,
+    "queryInfo": {
+        "distinctType": "None",
+        "top": null,
+        "offset": null,
+        "limit": null,
+        "orderBy": [
+            "Ascending"
+        ],
+        "orderByExpressions": [
+            "c.population"
+        ],
+        "groupByExpressions": [],
+        "groupByAliases": [],
+        "aggregates": [],
+        "groupByAliasToAggregateType": {},
+        "rewrittenQuery": "SELECT c._rid, [{\"item\": c.population}] AS orderByItems, {\"name\": c.name, \"population\": c.population} AS payload\nFROM c\nWHERE ({documentdb-formattableorderbyquery-filter})\nORDER BY c.population ASC",
+        "hasSelectValue": false,
+        "dCountInfo": null,
+        "hasNonStreamingOrderBy": false
+    },
+    "queryRanges": [
+        {
+            "min": "",
+            "max": "FF",
+            "isMinInclusive": true,
+            "isMaxInclusive": false
+        }
+    ],
+    "hybridSearchQueryInfo": null
+}

--- a/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_2_partitions/range_0.json
+++ b/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_2_partitions/range_0.json
@@ -1,0 +1,222 @@
+{
+    "_rid": "S9w7AIGecFs=",
+    "Documents": [
+        {
+            "_rid": "S9w7AIGecFsSAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "8982000"
+                }
+            ],
+            "payload": {
+                "name": "London",
+                "population": "8982000"
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsRAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "8419000"
+                }
+            ],
+            "payload": {
+                "name": "New York",
+                "population": "8419000"
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsBAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "62415"
+                }
+            ],
+            "payload": {
+                "name": "Al Fujayrah",
+                "population": "62415"
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsCAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "2956587"
+                }
+            ],
+            "payload": {
+                "name": "Dubai",
+                "population": "2956587"
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsQAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": "22256"
+                }
+            ],
+            "payload": {
+                "name": "Andorra la Vella",
+                "population": "22256"
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsNAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 13960000
+                }
+            ],
+            "payload": {
+                "name": "Tokyo",
+                "population": 13960000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsLAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 8982000
+                }
+            ],
+            "payload": {
+                "name": "London",
+                "population": 8982000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsIAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 8336817
+                }
+            ],
+            "payload": {
+                "name": "New York",
+                "population": 8336817
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsJAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 3979576
+                }
+            ],
+            "payload": {
+                "name": "Los Angeles",
+                "population": 3979576
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsPAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 3645000
+                }
+            ],
+            "payload": {
+                "name": "Berlin",
+                "population": 3645000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsDAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 3400800
+                }
+            ],
+            "payload": {
+                "name": "Dubai",
+                "population": 3400800
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsOAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 2753000
+                }
+            ],
+            "payload": {
+                "name": "Osaka",
+                "population": 2753000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsKAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 2693976
+                }
+            ],
+            "payload": {
+                "name": "Chicago",
+                "population": 2693976
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsFAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 1274749
+                }
+            ],
+            "payload": {
+                "name": "Sharjah",
+                "population": 1274749
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsMAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 553230
+                }
+            ],
+            "payload": {
+                "name": "Manchester",
+                "population": 553230
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsHAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 62000
+                }
+            ],
+            "payload": {
+                "name": "Umm Al Qaywayn",
+                "population": 62000
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsGAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 22256
+                }
+            ],
+            "payload": {
+                "name": "Andorra la Vella",
+                "population": 22256
+            }
+        },
+        {
+            "_rid": "S9w7AIGecFsEAAAAAAAAAA==",
+            "orderByItems": [
+                {
+                    "item": 15000
+                }
+            ],
+            "payload": {
+                "name": "Ar Ruways",
+                "population": 15000
+            }
+        }
+    ],
+    "_count": 18
+}

--- a/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_2_pkranges.json
+++ b/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_2_pkranges.json
@@ -1,0 +1,21 @@
+{
+    "_rid": "S9w7AIGecFs=",
+    "PartitionKeyRanges": [
+        {
+            "_rid": "S9w7AIGecFsCAAAAAAAAUA==",
+            "id": "0",
+            "_etag": "\"0000d642-0000-0100-0000-69de026a0000\"",
+            "minInclusive": "",
+            "maxExclusive": "FF",
+            "ridPrefix": 0,
+            "_self": "dbs/S9w7AA==/colls/S9w7AIGecFs=/pkranges/S9w7AIGecFsCAAAAAAAAUA==/",
+            "throughputFraction": 1,
+            "status": "online",
+            "parents": [],
+            "ownedArchivalPKRangeIds": [],
+            "_ts": 1776157290,
+            "lsn": 15
+        }
+    ],
+    "_count": 1
+}

--- a/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_2_plan.json
+++ b/sdk/data/azcosmos/queryengine/gonative/testdata/query_4_2_plan.json
@@ -1,0 +1,32 @@
+{
+    "partitionedQueryExecutionInfoVersion": 2,
+    "queryInfo": {
+        "distinctType": "None",
+        "top": null,
+        "offset": null,
+        "limit": null,
+        "orderBy": [
+            "Descending"
+        ],
+        "orderByExpressions": [
+            "c.population"
+        ],
+        "groupByExpressions": [],
+        "groupByAliases": [],
+        "aggregates": [],
+        "groupByAliasToAggregateType": {},
+        "rewrittenQuery": "SELECT c._rid, [{\"item\": c.population}] AS orderByItems, {\"name\": c.name, \"population\": c.population} AS payload\nFROM c\nWHERE ({documentdb-formattableorderbyquery-filter})\nORDER BY c.population DESC",
+        "hasSelectValue": false,
+        "dCountInfo": null,
+        "hasNonStreamingOrderBy": false
+    },
+    "queryRanges": [
+        {
+            "min": "",
+            "max": "FF",
+            "isMinInclusive": true,
+            "isMaxInclusive": false
+        }
+    ],
+    "hybridSearchQueryInfo": null
+}


### PR DESCRIPTION
Part 4 of 7 for [BYT-9239](https://linear.app/bytebase/issue/BYT-9239). Builds on Stages 0–2 (all merged).

## What unlocks

| # | Query | Was | Now |
|---|---|---|---|
| 4.1 | `SELECT c.name, c.population FROM c ORDER BY c.population ASC` | 400 | 18 rows in strict ASC order |
| 4.2 | `SELECT c.name, c.population FROM c ORDER BY c.population DESC` | 400 | 18 rows in strict DESC order |

Both verified end-to-end against the \`bytebase-cosmostest\` account. Since the WorldCities container has **mixed-type populations** (some numeric, some string), the result exercises the typed comparator's cross-type ordering:

- ASC: numbers first, then strings.
- DESC: strings first, then numbers.

Query 4.3 (multi-key ORDER BY) stays FAIL — it needs a Cosmos composite index the test container doesn't have.

## Implementation

- **\`merge.go\`** — \`orderByPipeline\` implementing \`queryengine.QueryPipeline\`. Uses \`container/heap\` for the k-way merge across gateway-sorted partition streams. Reuses \`compareItems\` from cmp.go (added in Stage 1 for MIN/MAX).
- **Placeholder substitution** — the gateway's rewritten query carries \`{documentdb-formattableorderbyquery-filter}\`; the pipeline substitutes \`true\` for the initial request per partition. Multi-page continuation (which would substitute a tail-comparison filter) is deferred.
- **Dispatch** — \`CreateQueryPipeline\` routes plans with \`len(orderBy) > 0\` to the new pipeline before the DISTINCT / aggregate checks, so any plan carrying an ORDER BY gets merged correctly.
- **\`SupportedFeatures()\`** — now \`\"Aggregate,NonValueAggregate,MultipleAggregates,Distinct,DistinctValue,OrderBy\"\`.
- **Wire-format notes** — captured fixtures show each document has \`orderByItems: [{item: <v>}]\` plus \`payload: {<row>}\`. Gateway sorts within each partition, the engine merges across.

## Scope

- DOES: single-key ORDER BY, ASC and DESC, with cross-type Cosmos item ordering.
- DOES NOT (deferred to later stages): multi-key ORDER BY (requires composite indexes), ordered DISTINCT composition (Stage 2's DISTINCT + Stage 3's merger — will be wired in a follow-up), continuation tokens / multi-page.

## Test plan

- [x] \`go build ./sdk/data/azcosmos/...\` clean.
- [x] \`go test -race ./sdk/data/azcosmos/... -count=1 -timeout 120s\` PASS across all 5 packages.
- [x] 13 new unit tests in \`merge_test.go\` (placeholder substitution, single/multi-partition merge in both directions, mixed-type ordering per Cosmos rules, empty partitions, malformed doc rejection, multi-key plan rejection, continuation-token rejection).
- [x] 2 fixture-backed end-to-end tests in \`pipeline_test.go\` asserting the captured 18-row results from both ASC and DESC queries.
- [x] 2 AZURE_COSMOS_KEY-guarded integration tests in \`integration_stage3_test.go\` verifying strict order across 18 rows against the live Cosmos account.